### PR TITLE
Integrate Sonarcloud into the repository

### DIFF
--- a/.sonarcloud.properties
+++ b/.sonarcloud.properties
@@ -1,0 +1,3 @@
+# Path to tests
+sonar.tests=tests
+

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 <img src="https://raw.githubusercontent.com/jasperweyne/helpless-kiwi/master/assets/image/readme-header.png" alt="helpless-kiwi" style="max-width:100%;">
 </p>
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=alert_status)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=coverage)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=ncloc)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi)
+
 | **Service** | **Master** | **Develop** |
 |-------------|------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | CI Status | ![CI](https://github.com/jasperweyne/helpless-kiwi/workflows/CI/badge.svg?branch=master) | ![CI](https://github.com/jasperweyne/helpless-kiwi/workflows/CI/badge.svg?branch=develop) |


### PR DESCRIPTION
For this project, a Sonarcloud integration has been added. This commit
integrates a number of Sonarcloud badges into the readme and indicates
the location of test code to Sonarcloud.