### PR TITLE
Integrate SonarCloud into the workflow

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -2,6 +2,10 @@ name: Testing
 
 on:
   pull_request:
+  push:
+    branches:
+      - master
+      - develop
 
 jobs:
   build:
@@ -28,3 +32,9 @@ jobs:
   
     - name: Run unit/functional tests
       run: composer test
+
+    - name: SonarCloud Scan
+      uses: sonarsource/sonarcloud-github-action@master
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        SONAR_TOKEN: ${{ secrets.SONAR_TOKEN }}

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 <img src="https://raw.githubusercontent.com/jasperweyne/helpless-kiwi/master/assets/image/readme-header.png" alt="helpless-kiwi" style="max-width:100%;">
 </p>
 
+[![Quality Gate Status](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=alert_status)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Coverage](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=coverage)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Reliability Rating](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=reliability_rating)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Maintainability Rating](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=sqale_rating)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Lines of Code](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=ncloc)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi) [![Duplicated Lines (%)](https://sonarcloud.io/api/project_badges/measure?project=jasperweyne_helpless-kiwi&metric=duplicated_lines_density)](https://sonarcloud.io/dashboard?id=jasperweyne_helpless-kiwi)
+
 | **Service** | **Master** | **Develop** |
 |-------------|------------------------------------------------------------------------------------------|-------------------------------------------------------------------------------------------|
 | CI Status | ![CI](https://github.com/jasperweyne/helpless-kiwi/workflows/CI/badge.svg?branch=master) | ![CI](https://github.com/jasperweyne/helpless-kiwi/workflows/CI/badge.svg?branch=develop) |

--- a/composer.json
+++ b/composer.json
@@ -81,7 +81,7 @@
             "@auto-scripts"
         ],
         "test": [
-            "php bin/phpunit --testdox tests"
+            "php bin/phpunit --testdox"
         ],
         "fix": [
             "php-cs-fixer fix src"

--- a/phpunit.xml.dist
+++ b/phpunit.xml.dist
@@ -20,6 +20,11 @@
             <directory>tests</directory>
         </testsuite>
     </testsuites>
+    
+    <logging>
+        <log type="coverage-clover" target="./var/reports/phpunit.coverage.xml"/>
+        <log type="junit" target="./var/reports/phpunit.xml"/>
+    </logging>
 
     <filter>
         <whitelist processUncoveredFilesFromWhitelist="true">

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -1,0 +1,9 @@
+sonar.organization=helpless-kiwi
+sonar.projectKey=jasperweyne_helpless-kiwi
+
+# relative paths to source directories. More details and properties are described
+# in https://sonarcloud.io/documentation/project-administration/narrowing-the-focus/ 
+sonar.exclusions=./tests/*
+sonar.tests=./tests
+sonar.php.tests.reportPath=./var/reports/phpunit.xml
+sonar.php.coverage.reportPaths=./var/reports/phpunit.coverage.xml


### PR DESCRIPTION
This commit integrates SonarCloud into the repository. It adds badges
to README.md, indicating the current health of the project. Moreover,
phpunit is integrated with SonarCloud through the newly added
sonar-project.properties. Composer.json and phpunit.xml.dist had to be
updated accordingly. Lastly, the testing workflow has actively
integrated a SonarCloud report.