### PR TITLE
Install PHP extensions in the gitpod dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -5,3 +5,6 @@ FROM gitpod/workspace-mysql
 # RUN brew install bastet
 #
 # More information: https://www.gitpod.io/docs/config-docker/
+
+RUN sudo apt-get update && \
+    sudo apt-get -y install php-xdebug


### PR DESCRIPTION
This commit adds the xdebug extension to the gitpod dockerfile. Since
the requirement has been added in the composer.json by 9e6b21e, the
gitpod has been broken. This change intends to fix that.