### PR TITLE
500 Error when creating account with already used email. 

### DIFF
--- a/src/Provider/LocalDataProvider.php
+++ b/src/Provider/LocalDataProvider.php
@@ -23,6 +23,13 @@ class LocalDataProvider implements PersonProviderInterface
         return $this->convert($auth);
     }
 
+    public function findPersonByEmail(string $email): ?Person
+    {
+        $auth = $this->em->getRepository(LocalAccount::class)->findOneBy(['email' => $email]);
+
+        return $this->convert($auth);
+    }
+
     public function findPersons(): array
     {
         return array_map([$this, 'convert'], $this->em->getRepository(LocalAccount::class)->findAll());
@@ -30,8 +37,9 @@ class LocalDataProvider implements PersonProviderInterface
 
     private function convert(?LocalAccount $auth): ?Person
     {
-        if (is_null($auth))
+        if (is_null($auth)) {
             return null;
+        }
 
         return $auth->getPerson();
     }

--- a/src/Provider/Person/PersonProviderInterface.php
+++ b/src/Provider/Person/PersonProviderInterface.php
@@ -5,5 +5,8 @@ namespace App\Provider\Person;
 interface PersonProviderInterface
 {
     public function findPerson(string $id): ?Person;
+
+    public function findPersonByEmail(string $email): ?Person;
+
     public function findPersons(): array;
 }

--- a/src/Provider/Person/PersonRegistry.php
+++ b/src/Provider/Person/PersonRegistry.php
@@ -13,13 +13,31 @@ final class PersonRegistry
 
     public function find(?string $id)
     {
-        if (is_null($id))
+        if (is_null($id)) {
             return null;
-            
+        }
+
         foreach ($this->providers as $provider) {
             $result = $provider->findPerson($id);
-            if ($result)
+            if ($result) {
                 return $result;
+            }
+        }
+
+        return null;
+    }
+
+    public function findPersonByEmail(?string $email)
+    {
+        if (is_null($email)) {
+            return null;
+        }
+
+        foreach ($this->providers as $provider) {
+            $result = $provider->findPersonByEmail($email);
+            if ($result) {
+                return $result;
+            }
         }
 
         return null;
@@ -31,7 +49,7 @@ final class PersonRegistry
         foreach ($this->providers as $provider) {
             $result = array_merge($result, $provider->findPersons());
         }
-        
+
         return $result;
     }
 }


### PR DESCRIPTION
Fixed the http 500 error when trying to create a account with an already used email.