### PR TITLE
Remove the phpunit pre commit hook

### DIFF
--- a/.hooks/pre-commit
+++ b/.hooks/pre-commit
@@ -30,48 +30,4 @@ fi
 
 echo "php-cs-fixer pre commit hook success"
 
-echo "phpunit pre commit hook start"
-
-PHPUNIT="bin/phpunit"
-PHPUNIT_ARGS=""
-
-# Define a location to save the output.
-PHPUNIT_LOG="phpunit_output_`date +%s`.log"
-
-# execute unit tests. (Assume that phpunit.xml is in root of project).
-OUTPUT=`${PHPUNIT} ${PHPUNIT_ARGS}`
-RETURNCODE=$?
-
-# Save the output of phpunit for posterity.
-echo "$OUTPUT" > "${LOGDIR}${PHPUNIT_LOG}"
-
-# if unit tests fail, output a summary and exit with failure code.
-if [ $RETURNCODE -ne 0 ]; then
-
-    # find the line with the summary.
-    while read -r line; do
-      if [[ $line =~ Failures: ]] ; then
-        summary=$line
-        break
-      fi
-    done <<< "$OUTPUT"
-
-    # output the status.
-    echo -e "  + Test suite failed with return code ${RETURNCODE}"
-    echo
-    echo -e "$summary"
-    echo
-
-    echo "  + The full output of phpunit has been saved in:"
-    echo -e "      ${LOGDIR}${PHPUNIT_LOG}"
-    echo
-
-    # abort the commit.
-    echo
-    echo "phpunit pre commit hook abort"
-    exit $RETURNCODE
-else
-  echo "phpunit pre commit hook success"
-fi
-
 exit 0


### PR DESCRIPTION
This PR removes the phpunit pre commit hook. It was introduced when no CI pipeline was present server side, thus requiring a form of verification client side to make sure that pull requests are valid. However, this hook executes on every commit, even if it's still work-in-progress. This PR completely removes the hook, given that it's intended use case has been superseded by the github testing workflow.