### PR TITLE
First commit, Fixed Bug #150

### DIFF
--- a/templates/activity/show.html.twig
+++ b/templates/activity/show.html.twig
@@ -66,7 +66,7 @@
 <div class="container row">
     <div class="grid-x">
         <div class="cell small-12 {{ is_granted('ROLE_USER') ? 'medium-8' : ''}}">
-            <p>{{ activity.description }}</p>
+            <p>{{ activity.description | nl2br }}</p>
         </div>
         {% if is_granted('ROLE_USER') %}
         <div class="cell medium-4 registrations">


### PR DESCRIPTION
Problem: Impossible to add enter spaces to a description for an activity. now possible.

Solved with recommended method by adding nl2br to a specific line in show.html.twig template.