### PR TITLE
Revert top bar spacing behaviour

### DIFF
--- a/assets/style/components/main/_nav.scss
+++ b/assets/style/components/main/_nav.scss
@@ -93,7 +93,8 @@
     .menu {
         @include flex-grid-row();
         @include flex-direction(column);
-        @include flex-align($x: spaced, $y: middle);
+        @include flex-align($x: null, $y: middle);
+        justify-content: space-between;
 
         padding: 2rem;
         display: none;


### PR DESCRIPTION
A regression broke the top bar spacing in the main UI. This commit fixes
that.