### PR TITLE
Show table heads on mobile

### DIFF
--- a/assets/style/components/_table.scss
+++ b/assets/style/components/_table.scss
@@ -49,7 +49,7 @@ table {
 
 @include breakpoint(small only) {
     table {
-        @include table-stack();
+        @include table-stack(true);
         tr {
             padding: 4px 0;
             


### PR DESCRIPTION
Previously, table heads were hidden on mobile. This was because big
tables might contain a long list of columns. However, in practice, this
seems to not be a big problem. Therefore, this commit changes that.