### PR TITLE
Hotfix for data override in Activity forms

### DIFF
--- a/src/Form/Activity/Admin/ActivityEditType.php
+++ b/src/Form/Activity/Admin/ActivityEditType.php
@@ -89,7 +89,7 @@ class ActivityEditType extends AbstractType
             ])
             ->add('capacity', IntegerType::class, [
                 'label' => 'Capaciteit',
-                'data' => 20,
+                'attr' => ['placeholder' => '20'],
                 'help' => 'Het maximaal aantal aanmeldingen, hierna word je op de reserve lijst aangemeld.',
             ])
             ->add('color', ChoiceType::class, [


### PR DESCRIPTION
Previously, a placeholder value was implemented in the activity forms for the
capacity field. However, this was done by overriding the data attribute in the
form, which modifies the actual data when an activity is editted. This is
unintended and can be easily overlooked by a user. This hotfix changes the
data attribute to the "attr" attribute, which directly integrates it into the
placeholder html attribute.