### PR TITLE
Groups can now only create activities for themselfs, or their child g…

### DIFF
--- a/src/Controller/Admin/ActivityController.php
+++ b/src/Controller/Admin/ActivityController.php
@@ -74,12 +74,19 @@ class ActivityController extends AbstractController
     public function newAction(Request $request)
     {
         $activity = new Activity();
+        $em = $this->getDoctrine()->getManager();
+        $usergroups = [];
 
-        $form = $this->createForm('App\Form\Activity\Admin\ActivityNewType', $activity);
+        if ($this->isGranted('ROLE_ADMIN')) {
+            $usergroups = $em->getRepository(Group::class)->findAll();
+        } else {
+            $usergroups = $em->getRepository(Group::class)->findSubGroupsForPerson($this->getUser());
+        }
+
+        $form = $this->createForm('App\Form\Activity\Admin\ActivityNewType', $activity, ['groups' => $usergroups]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
-            $em = $this->getDoctrine()->getManager();
             $em->persist($activity);
             $em->persist($activity->getLocation());
             $em->flush();
@@ -133,8 +140,16 @@ class ActivityController extends AbstractController
     public function editAction(Request $request, Activity $activity)
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
+        $em = $this->getDoctrine()->getManager();
+        $usergroups = [];
 
-        $form = $this->createForm('App\Form\Activity\Admin\ActivityEditType', $activity);
+        if ($this->isGranted('ROLE_ADMIN')) {
+            $usergroups = $em->getRepository(Group::class)->findAll();
+        } else {
+            $usergroups = $em->getRepository(Group::class)->findSubGroupsForPerson($this->getUser());
+        }
+
+        $form = $this->createForm('App\Form\Activity\Admin\ActivityEditType', $activity, ['groups' => $usergroups]);
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {

--- a/src/Form/Activity/Admin/ActivityEditType.php
+++ b/src/Form/Activity/Admin/ActivityEditType.php
@@ -37,10 +37,7 @@ class ActivityEditType extends AbstractType
                 'class' => 'App\Entity\Group\Group',
                 'required' => false,
                 'placeholder' => 'Geen groep',
-                'query_builder' => function (EntityRepository $er) {
-                    return $er->createQueryBuilder('t')
-                        ->andWhere('t.active = TRUE');
-                },
+                'choices' => $options['groups'],
                 'choice_label' => function ($ref) {
                     return $ref->getName();
                 },
@@ -114,6 +111,7 @@ class ActivityEditType extends AbstractType
     {
         $resolver->setDefaults([
             'data_class' => Activity::class,
+            'groups' => [],
         ]);
     }
 }

--- a/src/Form/Activity/Admin/ActivityNewType.php
+++ b/src/Form/Activity/Admin/ActivityNewType.php
@@ -25,6 +25,7 @@ class ActivityNewType extends ActivityEditType
     {
         $resolver->setDefaults([
             'data_class' => Activity::class,
+            'groups' => [],
         ]);
     }
 }

--- a/src/Repository/GroupRepository.php
+++ b/src/Repository/GroupRepository.php
@@ -34,6 +34,43 @@ class GroupRepository extends ServiceEntityRepository
         ;
     }
 
+    /**
+     * @return Group[] Returns an array of Group objects
+     */
+    public function findSubGroupsFor(Group $group, array $skipgroups = [])
+    {
+        $allsubgroups = [];
+        $qb = $this->createQueryBuilder('g');
+        $subgroups = $qb
+            ->andWhere('g.parent = :id')
+            ->setParameter('id', $group->getId())
+            ->getQuery()
+            ->getResult();
+
+        for ($i = 0; $i < count($subgroups); ++$i) {
+            $tempgroup = $subgroups[$i];
+            $allsubgroups = array_merge($allsubgroups, [...$this->findSubGroupsFor($tempgroup)]);
+            array_push($allsubgroups, $subgroups[$i]);
+        }
+
+        return $allsubgroups;
+    }
+
+    /**
+     * @return Group[] Returns an array of Group objects
+     */
+    public function findSubGroupsForPerson(LocalAccount $person)
+    {
+        $allgroups = [];
+        $groups = $this->findAllFor($person);
+        $allgroups = array_merge($groups, $allgroups);
+        foreach ($groups as $group) {
+            $allgroups = array_merge($this->findSubGroupsFor($group), $allgroups);
+        }
+
+        return $allgroups;
+    }
+
     // /**
     //  * @return Group[] Returns an array of Group objects
     //  */

--- a/src/Repository/GroupRepository.php
+++ b/src/Repository/GroupRepository.php
@@ -47,10 +47,9 @@ class GroupRepository extends ServiceEntityRepository
             ->getQuery()
             ->getResult();
 
-        for ($i = 0; $i < count($subgroups); ++$i) {
-            $tempgroup = $subgroups[$i];
-            $allsubgroups = array_merge($allsubgroups, [...$this->findSubGroupsFor($tempgroup)]);
-            array_push($allsubgroups, $subgroups[$i]);
+        foreach ($subgroups as $group) {
+            $allsubgroups = array_merge($allsubgroups, [...$this->findSubGroupsFor($group)]);
+            array_push($allsubgroups, $group);
         }
 
         return $allsubgroups;

--- a/tests/Unit/Repository/GroupRepositoryTest.php
+++ b/tests/Unit/Repository/GroupRepositoryTest.php
@@ -51,4 +51,16 @@ class GroupRepositoryTest extends KernelTestCase
         /* @todo This test is incomplete. */
         $this->markTestIncomplete();
     }
+
+    public function testFindSubGroupsFor(): void
+    {
+        /* @todo This test is incomplete. */
+        $this->markTestIncomplete();
+    }
+
+    public function testFindSubGroupsForUser(): void
+    {
+        /* @todo This test is incomplete. */
+        $this->markTestIncomplete();
+    }
 }


### PR DESCRIPTION
…roups.

ActivityController: In the NewAction and EditAction, added code that gets an array of the groups it may use.

ActivityEditType: Added a group array variable in the options

ActivityNewType: Same as ActivityEditType

GroupRepository: Added 2 new repository functions. Get all childgroups of a group, and get all groups including childgroups of a person.

Known error: When a person from a group creates an activity, If this user selects the activity is not organised by a group, it returns a no access exception. However the activity is published