### PR TITLE
Static code analysis

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -33,8 +33,14 @@ jobs:
       env:
         APP_ENV: test
   
+    - name: Run linter
+      run: composer lint
+
     - name: Run unit/functional tests
       run: composer test
+      
+    - name: Run static code analyser
+      run: composer analyse
 
     - name: fix code coverage paths
       working-directory: ./var/reports

--- a/composer.json
+++ b/composer.json
@@ -45,6 +45,11 @@
         "friendsofphp/php-cs-fixer": "^2.14",
         "liip/test-fixtures-bundle": "^1.0.0",
         "overblog/graphiql-bundle": "^0.2.1",
+        "phpstan/extension-installer": "^1.1",
+        "phpstan/phpstan": "^1.4",
+        "phpstan/phpstan-doctrine": "^1.2",
+        "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-symfony": "^1.1",
         "symfony/css-selector": "4.4.*",
         "symfony/debug-pack": "*",
         "symfony/maker-bundle": "^1.0",
@@ -96,8 +101,14 @@
         "test": [
             "php bin/phpunit --testdox"
         ],
+        "lint": [
+            "php-cs-fixer fix src --verbose --dry-run --show-progress=none"
+        ],
         "fix": [
             "php-cs-fixer fix src"
+        ],
+        "analyse": [
+            "./vendor/bin/phpstan analyse --memory-limit 2G"
         ],
         "db-rebuild": [
             "php bin/console doctrine:database:drop --force --if-exists",

--- a/composer.json
+++ b/composer.json
@@ -49,6 +49,7 @@
         "phpstan/phpstan": "^1.4",
         "phpstan/phpstan-doctrine": "^1.2",
         "phpstan/phpstan-phpunit": "^1.0",
+        "phpstan/phpstan-strict-rules": "^1.1",
         "phpstan/phpstan-symfony": "^1.1",
         "symfony/css-selector": "4.4.*",
         "symfony/debug-pack": "*",

--- a/composer.json
+++ b/composer.json
@@ -64,7 +64,8 @@
         "sort-packages": true,
         "allow-plugins": {
             "ocramius/package-versions": true,
-            "symfony/flex": true
+            "symfony/flex": true,
+            "phpstan/extension-installer": true
         }
     },
     "autoload": {

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "87f1c9669214f146e95405e755de01db",
+    "content-hash": "c0e49a4a6e8155be486161dfaf210077",
     "packages": [
         {
             "name": "dg/mysql-dump",
@@ -9307,6 +9307,57 @@
             "time": "2021-10-14T08:03:54+00:00"
         },
         {
+            "name": "phpstan/phpstan-strict-rules",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-strict-rules.git",
+                "reference": "e12d55f74a8cca18c6e684c6450767e055ba7717"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-strict-rules/zipball/e12d55f74a8cca18c6e684c6450767e055ba7717",
+                "reference": "e12d55f74a8cca18c6e684c6450767e055ba7717",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.2.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Extra strict and opinionated rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-strict-rules/issues",
+                "source": "https://github.com/phpstan/phpstan-strict-rules/tree/1.1.0"
+            },
+            "time": "2021-11-18T09:30:29+00:00"
+        },
+        {
             "name": "phpstan/phpstan-symfony",
             "version": "1.1.7",
             "source": {
@@ -10205,5 +10256,5 @@
         "ext-sqlite3": "*",
         "ext-xdebug": "*"
     },
-    "plugin-api-version": "2.1.0"
+    "plugin-api-version": "2.2.0"
 }

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "1a72161c18b4faef348f6a83104d48ec",
+    "content-hash": "87f1c9669214f146e95405e755de01db",
     "packages": [
         {
             "name": "dg/mysql-dump",
@@ -9070,6 +9070,315 @@
                 "source": "https://github.com/PHP-CS-Fixer/diff/tree/v1.3.1"
             },
             "time": "2020-10-14T08:39:05+00:00"
+        },
+        {
+            "name": "phpstan/extension-installer",
+            "version": "1.1.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/extension-installer.git",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/extension-installer/zipball/66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "reference": "66c7adc9dfa38b6b5838a9fb728b68a7d8348051",
+                "shasum": ""
+            },
+            "require": {
+                "composer-plugin-api": "^1.1 || ^2.0",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": ">=0.11.6"
+            },
+            "require-dev": {
+                "composer/composer": "^1.8",
+                "phing/phing": "^2.16.3",
+                "php-parallel-lint/php-parallel-lint": "^1.2.0",
+                "phpstan/phpstan-strict-rules": "^0.11 || ^0.12"
+            },
+            "type": "composer-plugin",
+            "extra": {
+                "class": "PHPStan\\ExtensionInstaller\\Plugin"
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\ExtensionInstaller\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Composer plugin for automatic installation of PHPStan extensions",
+            "support": {
+                "issues": "https://github.com/phpstan/extension-installer/issues",
+                "source": "https://github.com/phpstan/extension-installer/tree/1.1.0"
+            },
+            "time": "2020-12-13T13:06:13+00:00"
+        },
+        {
+            "name": "phpstan/phpstan",
+            "version": "1.4.9",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan.git",
+                "reference": "1a45f44d319cf000a8c960af6b7435741e944771"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan/zipball/1a45f44d319cf000a8c960af6b7435741e944771",
+                "reference": "1a45f44d319cf000a8c960af6b7435741e944771",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1|^8.0"
+            },
+            "conflict": {
+                "phpstan/phpstan-shim": "*"
+            },
+            "bin": [
+                "phpstan",
+                "phpstan.phar"
+            ],
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.4-dev"
+                }
+            },
+            "autoload": {
+                "files": [
+                    "bootstrap.php"
+                ]
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPStan - PHP Static Analysis Tool",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan/issues",
+                "source": "https://github.com/phpstan/phpstan/tree/1.4.9"
+            },
+            "funding": [
+                {
+                    "url": "https://github.com/ondrejmirtes",
+                    "type": "github"
+                },
+                {
+                    "url": "https://github.com/phpstan",
+                    "type": "github"
+                },
+                {
+                    "url": "https://www.patreon.com/phpstan",
+                    "type": "patreon"
+                },
+                {
+                    "url": "https://tidelift.com/funding/github/packagist/phpstan/phpstan",
+                    "type": "tidelift"
+                }
+            ],
+            "time": "2022-03-10T08:52:08+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-doctrine",
+            "version": "1.2.11",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-doctrine.git",
+                "reference": "580737eff27e48c1924bc019fa43343626242e91"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-doctrine/zipball/580737eff27e48c1924bc019fa43343626242e91",
+                "reference": "580737eff27e48c1924bc019fa43343626242e91",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.4.1"
+            },
+            "conflict": {
+                "doctrine/collections": "<1.0",
+                "doctrine/common": "<2.7",
+                "doctrine/mongodb-odm": "<1.2",
+                "doctrine/orm": "<2.5",
+                "doctrine/persistence": "<1.3"
+            },
+            "require-dev": {
+                "doctrine/annotations": "^1.11.0",
+                "doctrine/collections": "^1.6",
+                "doctrine/common": "^2.7 || ^3.0",
+                "doctrine/dbal": "^2.13.7 || ^3.0",
+                "doctrine/lexer": "^1.2.1",
+                "doctrine/mongodb-odm": "^1.3 || ^2.1",
+                "doctrine/orm": "^2.11.0",
+                "doctrine/persistence": "^1.3.8 || ^2.2.1",
+                "nesbot/carbon": "^2.49",
+                "nikic/php-parser": "^4.13.2",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5.10",
+                "ramsey/uuid-doctrine": "^1.5.0",
+                "symfony/cache": "^4.4.35"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.2-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "Doctrine extensions for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-doctrine/issues",
+                "source": "https://github.com/phpstan/phpstan-doctrine/tree/1.2.11"
+            },
+            "time": "2022-02-23T15:14:45+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-phpunit",
+            "version": "1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-phpunit.git",
+                "reference": "9eb88c9f689003a8a2a5ae9e010338ee94dc39b3"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-phpunit/zipball/9eb88c9f689003a8a2a5ae9e010338ee94dc39b3",
+                "reference": "9eb88c9f689003a8a2a5ae9e010338ee94dc39b3",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.0"
+            },
+            "conflict": {
+                "phpunit/phpunit": "<7.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "description": "PHPUnit extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-phpunit/issues",
+                "source": "https://github.com/phpstan/phpstan-phpunit/tree/1.0.0"
+            },
+            "time": "2021-10-14T08:03:54+00:00"
+        },
+        {
+            "name": "phpstan/phpstan-symfony",
+            "version": "1.1.7",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/phpstan/phpstan-symfony.git",
+                "reference": "8ef80f5c4f70ebd31a55647bc082ea9df4bf0132"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/phpstan/phpstan-symfony/zipball/8ef80f5c4f70ebd31a55647bc082ea9df4bf0132",
+                "reference": "8ef80f5c4f70ebd31a55647bc082ea9df4bf0132",
+                "shasum": ""
+            },
+            "require": {
+                "ext-simplexml": "*",
+                "php": "^7.1 || ^8.0",
+                "phpstan/phpstan": "^1.4"
+            },
+            "conflict": {
+                "symfony/framework-bundle": "<3.0"
+            },
+            "require-dev": {
+                "nikic/php-parser": "^4.13.0",
+                "php-parallel-lint/php-parallel-lint": "^1.2",
+                "phpstan/phpstan-phpunit": "^1.0",
+                "phpstan/phpstan-strict-rules": "^1.0",
+                "phpunit/phpunit": "^9.5",
+                "psr/container": "1.0 || 1.1.1",
+                "symfony/config": "^4.2 || ^5.0",
+                "symfony/console": "^4.0 || ^5.0",
+                "symfony/dependency-injection": "^4.0 || ^5.0",
+                "symfony/form": "^4.0 || ^5.0",
+                "symfony/framework-bundle": "^4.4 || ^5.0",
+                "symfony/http-foundation": "^5.1",
+                "symfony/messenger": "^4.2 || ^5.0",
+                "symfony/polyfill-php80": "^1.24",
+                "symfony/serializer": "^4.0 || ^5.0"
+            },
+            "type": "phpstan-extension",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                },
+                "phpstan": {
+                    "includes": [
+                        "extension.neon",
+                        "rules.neon"
+                    ]
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "PHPStan\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Lukáš Unger",
+                    "email": "looky.msc@gmail.com",
+                    "homepage": "https://lookyman.net"
+                }
+            ],
+            "description": "Symfony Framework extensions and rules for PHPStan",
+            "support": {
+                "issues": "https://github.com/phpstan/phpstan-symfony/issues",
+                "source": "https://github.com/phpstan/phpstan-symfony/tree/1.1.7"
+            },
+            "time": "2022-02-25T19:36:13+00:00"
         },
         {
             "name": "symfony/browser-kit",

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -31,6 +31,11 @@ parameters:
 			path: src/Calendar/ICalProvider.php
 
 		-
+			message: "#^Only booleans are allowed in a ternary operator condition, App\\\\Entity\\\\Group\\\\Group\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
 			message: "#^Parameter \\#1 \\$description of method Jsvrcek\\\\ICS\\\\Model\\\\CalendarEvent\\:\\:setDescription\\(\\) expects string, string\\|null given\\.$#"
 			count: 1
 			path: src/Calendar/ICalProvider.php
@@ -81,6 +86,16 @@ parameters:
 			path: src/Command/CreateLocalAccountCommand.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, array\\<string\\>\\|string\\|null given\\.$#"
+			count: 2
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, array\\<string\\>\\|bool\\|string\\|null given\\.$#"
+			count: 1
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
 			message: "#^Property App\\\\Command\\\\CreateLocalAccountCommand\\:\\:\\$em has no type specified\\.$#"
 			count: 1
 			path: src/Command/CreateLocalAccountCommand.php
@@ -104,6 +119,11 @@ parameters:
 			message: "#^Property App\\\\Command\\\\HasLocalAccountCommand\\:\\:\\$em has no type specified\\.$#"
 			count: 1
 			path: src/Command/HasLocalAccountCommand.php
+
+		-
+			message: "#^Call to method App\\\\Calendar\\\\ICalProvider\\:\\:icalFeed\\(\\) with incorrect case\\: IcalFeed$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:callIcal\\(\\) has no return type specified\\.$#"
@@ -148,6 +168,11 @@ parameters:
 		-
 			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:unregisterAction\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, object\\|null given\\.$#"
+			count: 2
 			path: src/Controller/Activity/ActivityController.php
 
 		-
@@ -361,6 +386,21 @@ parameters:
 			path: src/Controller/Admin/GroupController.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, App\\\\Entity\\\\Group\\\\Group\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, App\\\\Entity\\\\Group\\\\Group\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
 			message: "#^Property App\\\\Controller\\\\Admin\\\\GroupController\\:\\:\\$events has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Admin/GroupController.php
@@ -444,6 +484,11 @@ parameters:
 			message: "#^Parameter \\#1 \\$route of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:generateUrl\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
 
 		-
 			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:createDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
@@ -603,6 +648,11 @@ parameters:
 		-
 			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:updateRegistration\\(\\) has no return type specified\\.$#"
 			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, App\\\\Entity\\\\Security\\\\LocalAccount\\|null given\\.$#"
+			count: 4
 			path: src/Controller/Helper/RegistrationHelper.php
 
 		-
@@ -811,6 +861,11 @@ parameters:
 			path: src/Controller/Security/LoginController.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, Symfony\\\\Component\\\\Security\\\\Core\\\\Exception\\\\AuthenticationException\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Security/LoginController.php
+
+		-
 			message: "#^Cannot access offset 'email' on mixed\\.$#"
 			count: 1
 			path: src/Controller/Security/PasswordController.php
@@ -846,6 +901,11 @@ parameters:
 			path: src/Controller/Security/PasswordController.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, App\\\\Entity\\\\Security\\\\LocalAccount\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
 			message: "#^Parameter \\#1 \\$email of method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setEmail\\(\\) expects string, mixed given\\.$#"
 			count: 1
 			path: src/Controller/Security/PasswordController.php
@@ -864,6 +924,11 @@ parameters:
 			message: "#^Property App\\\\Controller\\\\Security\\\\PasswordController\\:\\:\\$passwordReset has no type specified\\.$#"
 			count: 1
 			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
 
 		-
 			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:getOptions\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
@@ -892,6 +957,16 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Only booleans are allowed in &&, DateTime\\|null given on the right side\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, App\\\\Entity\\\\Security\\\\LocalAccount\\|null given\\.$#"
 			count: 1
 			path: src/Entity/Activity/Activity.php
 
@@ -1077,6 +1152,11 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:setPresent\\(\\) has parameter \\$present with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, App\\\\Entity\\\\Order\\|null given\\.$#"
 			count: 1
 			path: src/Entity/Activity/Registration.php
 
@@ -1371,6 +1451,21 @@ parameters:
 			path: src/Entity/Order.php
 
 		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Casting to string something that's already string\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Instanceof between DateTime and DateTime will always evaluate to true\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
 			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:__toString\\(\\) should return string but returns string\\|null\\.$#"
 			count: 1
 			path: src/Entity/Security/LocalAccount.php
@@ -1583,6 +1678,11 @@ parameters:
 		-
 			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$roles has no type specified\\.$#"
 			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Short ternary operator is not allowed\\. Use null coalesce operator if applicable or consider using long ternary\\.$#"
+			count: 2
 			path: src/Entity/Security/LocalAccount.php
 
 		-
@@ -1806,6 +1906,11 @@ parameters:
 			path: src/GraphQL/Query.php
 
 		-
+			message: "#^Only booleans are allowed in &&, App\\\\Entity\\\\Security\\\\LocalAccount\\|null given on the right side\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
 			message: "#^Property App\\\\GraphQL\\\\Query\\:\\:\\$em has no type specified\\.$#"
 			count: 1
 			path: src/GraphQL/Query.php
@@ -1867,6 +1972,16 @@ parameters:
 
 		-
 			message: "#^Method App\\\\Group\\\\OrganiseMenuExtension\\:\\:getUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Group/OrganiseMenuExtension.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, array given\\.$#"
+			count: 1
+			path: src/Group/OrganiseMenuExtension.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, bool\\|null given\\.$#"
 			count: 1
 			path: src/Group/OrganiseMenuExtension.php
 
@@ -2111,6 +2226,11 @@ parameters:
 			path: src/Log/Doctrine/EntityUpdateEvent.php
 
 		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
 			message: "#^Cannot access offset 'entityCb' on mixed\\.$#"
 			count: 1
 			path: src/Log/EventService.php
@@ -2286,6 +2406,16 @@ parameters:
 			path: src/Reflection/ClassNameService.php
 
 		-
+			message: "#^Only booleans are allowed in an if condition, int\\|false given\\.$#"
+			count: 1
+			path: src/Reflection/ClassNameService.php
+
+		-
+			message: "#^App\\\\Reflection\\\\ReflectionService\\:\\:__construct\\(\\) does not call parent constructor from Doctrine\\\\Persistence\\\\Mapping\\\\RuntimeReflectionService\\.$#"
+			count: 1
+			path: src/Reflection/ReflectionService.php
+
+		-
 			message: "#^Method App\\\\Reflection\\\\ReflectionService\\:\\:getAllProperties\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: src/Reflection/ReflectionService.php
@@ -2456,6 +2586,16 @@ parameters:
 			path: src/Security/LocalAuthenticator.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface given\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Only booleans are allowed in an if condition, string\\|null given\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
 			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
 			count: 1
 			path: src/Security/LocalAuthenticator.php
@@ -2601,6 +2741,26 @@ parameters:
 			path: src/Template/AnnotationMenuExtension.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, Symfony\\\\Component\\\\Routing\\\\Annotation\\\\Route\\|null given\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Only booleans are allowed in a negated boolean, array given\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, Symfony\\\\Component\\\\Routing\\\\Annotation\\\\Route\\|null given\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
 			message: """
 				#^PHPDoc tag @param has invalid value \\(\\$directory
 				  The directory of the menu items\\)\\: Unexpected token "\\$directory", expected type at offset 125$#
@@ -2693,6 +2853,11 @@ parameters:
 
 		-
 			message: "#^Cannot call method setToken\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Construct empty\\(\\) is not allowed\\. Use more strict comparison\\.$#"
 			count: 1
 			path: src/Tests/AuthWebTestCase.php
 
@@ -2792,6 +2957,11 @@ parameters:
 			path: src/Tests/Database/Security/LocalAccountFixture.php
 
 		-
+			message: "#^Call to function in_array\\(\\) requires parameter \\#3 to be set\\.$#"
+			count: 2
+			path: src/Tests/TestData.php
+
+		-
 			message: "#^Method App\\\\Tests\\\\TestData\\:\\:__construct\\(\\) has parameter \\$initial with no type specified\\.$#"
 			count: 1
 			path: src/Tests/TestData.php
@@ -2852,6 +3022,11 @@ parameters:
 			path: src/Tests/TestData.php
 
 		-
+			message: "#^Only booleans are allowed in a negated boolean, mixed given\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
 			message: "#^PHPDoc tag @throws with type App\\\\Tests\\\\UnexpectedValueException is not subtype of Throwable$#"
 			count: 1
 			path: src/Tests/TestData.php
@@ -2882,6 +3057,16 @@ parameters:
 			path: src/Tests/TestData.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertContains\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 3
+			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
+
+		-
 			message: "#^Method Tests\\\\Functional\\\\Command\\\\CreateLocalAccountCommandTest\\:\\:testExecute\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
@@ -2895,6 +3080,11 @@ parameters:
 			message: "#^Property Tests\\\\Functional\\\\Command\\\\CreateLocalAccountCommandTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Command/HasLocalAccountCommandTest.php
 
 		-
 			message: "#^Method Tests\\\\Functional\\\\Command\\\\HasLocalAccountCommandTest\\:\\:testExecuteEmpty\\(\\) has no return type specified\\.$#"
@@ -2917,13 +3107,58 @@ parameters:
 			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
 
 		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with App\\\\Entity\\\\Activity\\\\DateTime will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
 			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 4
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
 			count: 2
 			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
 
 		-
 			message: "#^Cannot call method setValue\\(\\) on array\\<array\\<Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\>\\|Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\>\\|Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\.$#"
 			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 9
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 2
 			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
 
 		-
@@ -2957,6 +3192,16 @@ parameters:
 			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/AdminControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/EventControllerTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$events of class App\\\\Controller\\\\Admin\\\\EventController constructor expects App\\\\Log\\\\EventService, object\\|null given\\.$#"
 			count: 1
 			path: tests/Functional/Controller/Admin/EventControllerTest.php
@@ -2967,6 +3212,26 @@ parameters:
 			path: tests/Functional/Controller/Admin/EventControllerTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertContains\\(\\)\\.$#"
+			count: 3
+			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 9
+			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotContains\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
 			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\GroupControllerTest\\:\\:\\$controllerEndpoint has no type specified\\.$#"
 			count: 1
 			path: tests/Functional/Controller/Admin/GroupControllerTest.php
@@ -2975,6 +3240,16 @@ parameters:
 			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\GroupControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Admin/MailControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Admin/MailControllerTest.php
 
 		-
 			message: "#^Parameter \\#2 \\$text of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\) expects string, string\\|null given\\.$#"
@@ -2992,6 +3267,11 @@ parameters:
 			path: tests/Functional/Controller/Admin/MailControllerTest.php
 
 		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with App\\\\Entity\\\\Activity\\\\DateTime will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
 			message: "#^Cannot call method getComment\\(\\) on App\\\\Entity\\\\Activity\\\\Registration\\|null\\.$#"
 			count: 1
 			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
@@ -3004,6 +3284,21 @@ parameters:
 		-
 			message: "#^Cannot call method getRegistrations\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
 			count: 2
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 13
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 5
 			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
 
 		-
@@ -3032,6 +3327,36 @@ parameters:
 			path: tests/Functional/Controller/Admin/SecurityControllerTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 6
+			path: tests/Functional/Controller/Admin/SecurityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 4
+			path: tests/Functional/Controller/Admin/SecurityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/SecurityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 10
+			path: tests/Functional/Controller/Organise/ActivityControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Organise/OrganiseControllerTest.php
+
+		-
+			message: "#^Call to method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\) with App\\\\Entity\\\\Activity\\\\DateTime will always evaluate to true\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
 			message: "#^Cannot call method getComment\\(\\) on App\\\\Entity\\\\Activity\\\\Registration\\|null\\.$#"
 			count: 1
 			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
@@ -3057,9 +3382,39 @@ parameters:
 			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 13
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotNull\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 5
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
 			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Organise\\\\RegistrationControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 5
+			path: tests/Functional/Controller/Security/LoginControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/LoginControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/LoginControllerTest.php
 
 		-
 			message: "#^Method Tests\\\\Functional\\\\Controller\\\\Security\\\\LoginControllerTest\\:\\:setupOidc\\(\\) has parameter \\$container with no type specified\\.$#"
@@ -3084,6 +3439,16 @@ parameters:
 		-
 			message: "#^Access to an undefined property Tests\\\\Functional\\\\Controller\\\\Security\\\\PasswordControllerTest\\:\\:\\$userProvider\\.$#"
 			count: 5
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 10
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Dynamic call to static method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\)\\.$#"
+			count: 6
 			path: tests/Functional/Controller/Security/PasswordControllerTest.php
 
 		-
@@ -3112,6 +3477,36 @@ parameters:
 			path: tests/Functional/Controller/Security/PasswordControllerTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertArrayNotHasKey\\(\\)\\.$#"
+			count: 10
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertCount\\(\\)\\.$#"
+			count: 5
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 10
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotEmpty\\(\\)\\.$#"
+			count: 3
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\)\\.$#"
+			count: 5
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 6
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
 			message: "#^Method Tests\\\\Functional\\\\GraphQL\\\\QueryTest\\:\\:graphqlQuery\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
 			count: 1
 			path: tests/Functional/GraphQL/QueryTest.php
@@ -3137,7 +3532,47 @@ parameters:
 			path: tests/Functional/GraphQL/QueryTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/ActivityCountPresentTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/ActivityEditPresentTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/ActivityEditTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/ActivityImageTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/ActivityNewTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/ActivitySetPresentAmountTest.php
+
+		-
 			message: "#^Cannot call method create\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityEditTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/Admin/ActivityEditTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:exactly\\(\\)\\.$#"
 			count: 1
 			path: tests/Integration/Form/Activity/Admin/ActivityEditTypeTest.php
 
@@ -3148,6 +3583,16 @@ parameters:
 
 		-
 			message: "#^Cannot call method create\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityNewTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/Admin/ActivityNewTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:exactly\\(\\)\\.$#"
 			count: 1
 			path: tests/Integration/Form/Activity/Admin/ActivityNewTypeTest.php
 
@@ -3167,6 +3612,16 @@ parameters:
 			path: tests/Integration/Form/Activity/PresentTypeTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/PresentTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:exactly\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/PresentTypeTest.php
+
+		-
 			message: "#^Method Tests\\\\Integration\\\\Form\\\\Activity\\\\PresentTypeTest\\:\\:testBindValidData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Integration/Form/Activity/PresentTypeTest.php
@@ -3182,6 +3637,11 @@ parameters:
 			path: tests/Integration/Form/Activity/RegistrationEditTypeTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/RegistrationEditTypeTest.php
+
+		-
 			message: "#^Method Tests\\\\Integration\\\\Form\\\\Activity\\\\RegistrationEditTypeTest\\:\\:testBindValidData\\(\\) has no return type specified\\.$#"
 			count: 1
 			path: tests/Integration/Form/Activity/RegistrationEditTypeTest.php
@@ -3192,9 +3652,24 @@ parameters:
 			path: tests/Integration/Form/Activity/RegistrationTypeTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Activity/RegistrationTypeTest.php
+
+		-
 			message: "#^Property Tests\\\\Integration\\\\Form\\\\Activity\\\\RegistrationTypeTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Integration/Form/Activity/RegistrationTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Group/GroupTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Group/RelationAddTypeTest.php
 
 		-
 			message: "#^Access to an undefined property Tests\\\\Integration\\\\Form\\\\Group\\\\RelationTypeTest\\:\\:\\$relationType\\.$#"
@@ -3202,8 +3677,38 @@ parameters:
 			path: tests/Integration/Form/Group/RelationTypeTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Group/RelationTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Location/LocationTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Security/LocalAccountTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Security/NewPasswordTypeTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Integration/Form/Security/PasswordRequestTypeTest.php
+
+		-
 			message: "#^Cannot call method format\\(\\) on DateTime\\|null\\.$#"
 			count: 2
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\)\\.$#"
+			count: 14
 			path: tests/Unit/Calendar/ICalProviderTest.php
 
 		-
@@ -3237,6 +3742,21 @@ parameters:
 			path: tests/Unit/Entity/Activity/ActivityTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotSame\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 36
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
 			message: "#^PHPDoc tag @var contains unknown class Tests\\\\Unit\\\\Entity\\\\Activity\\\\MockObject\\.$#"
 			count: 1
 			path: tests/Unit/Entity/Activity/ActivityTest.php
@@ -3260,6 +3780,21 @@ parameters:
 			message: "#^Cannot access offset 0 on mixed\\.$#"
 			count: 1
 			path: tests/Unit/Entity/Activity/PriceOptionTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotSame\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/PriceOptionTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 17
+			path: tests/Unit/Entity/Activity/PriceOptionTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 20
+			path: tests/Unit/Entity/Activity/RegistrationTest.php
 
 		-
 			message: "#^Method Tests\\\\Unit\\\\Entity\\\\Activity\\\\RegistrationTest\\:\\:testGetComment\\(\\) has no return type specified\\.$#"
@@ -3287,9 +3822,59 @@ parameters:
 			path: tests/Unit/Entity/Activity/RegistrationTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 19
+			path: tests/Unit/Entity/Group/GroupTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 5
+			path: tests/Unit/Entity/Group/GroupTest.php
+
+		-
 			message: "#^You should use assertTrue\\(\\) instead of assertSame\\(\\) when expecting \"true\"$#"
 			count: 9
 			path: tests/Unit/Entity/Group/GroupTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 10
+			path: tests/Unit/Entity/Group/RelationTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 5
+			path: tests/Unit/Entity/Group/RelationTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Entity/Location/LocationTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 13
+			path: tests/Unit/Entity/Log/EventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 12
+			path: tests/Unit/Entity/Mail/MailTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Mail/MailTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 5
+			path: tests/Unit/Entity/Mail/RecipientTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 4
+			path: tests/Unit/Entity/OrderTest.php
 
 		-
 			message: "#^Cannot call method add\\(\\) on mixed\\.$#"
@@ -3297,9 +3882,49 @@ parameters:
 			path: tests/Unit/Entity/Security/LocalAccountTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertContains\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNotContains\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertNull\\(\\)\\.$#"
+			count: 4
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 31
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:once\\(\\)\\.$#"
+			count: 4
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
 			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
 			count: 2
 			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/EventListener/DoctrineTablePrefixListenerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertEquals\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/GraphQL/Types/DatetimeScalarTest.php
 
 		-
 			message: "#^Method Tests\\\\Unit\\\\GraphQL\\\\Types\\\\DatetimeScalarTest\\:\\:testParseLiteral\\(\\) has no return type specified\\.$#"
@@ -3317,6 +3942,11 @@ parameters:
 			path: tests/Unit/GraphQL/Types/DatetimeScalarTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Group/GroupMenuExtensionTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$em of class App\\\\Group\\\\GroupMenuExtension constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
 			count: 1
 			path: tests/Unit/Group/GroupMenuExtensionTest.php
@@ -3325,6 +3955,11 @@ parameters:
 			message: "#^Property Tests\\\\Unit\\\\Group\\\\GroupMenuExtensionTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Unit/Group/GroupMenuExtensionTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Group/OrganiseMenuExtensionTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$em of class App\\\\Group\\\\OrganiseMenuExtension constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
@@ -3347,9 +3982,24 @@ parameters:
 			path: tests/Unit/Group/OrganiseMenuExtensionTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 5
+			path: tests/Unit/Log/AbstractEventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Log/AbstractEventTest.php
+
+		-
 			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
 			count: 1
 			path: tests/Unit/Log/AbstractEventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Log/Doctrine/EntityEventListenerTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$eventService of class App\\\\Log\\\\Doctrine\\\\EntityEventListener constructor expects App\\\\Log\\\\EventService, object\\|null given\\.$#"
@@ -3370,6 +4020,31 @@ parameters:
 			message: "#^Property Tests\\\\Unit\\\\Log\\\\Doctrine\\\\EntityEventListenerTest\\:\\:\\$reflService \\(App\\\\Reflection\\\\ReflectionService\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Unit/Log/Doctrine/EntityEventListenerTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Log/Doctrine/EntityNewEventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Log/Doctrine/EntityNewEventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Log/Doctrine/EntityUpdateEventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Log/Doctrine/EntityUpdateEventTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 8
+			path: tests/Unit/Log/EventServiceTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$em of class App\\\\Log\\\\EventService constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
@@ -3402,6 +4077,31 @@ parameters:
 			path: tests/Unit/Log/EventServiceTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:atLeastOnce\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Mail/MailServiceTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:never\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Mail/MailServiceTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:once\\(\\)\\.$#"
+			count: 2
+			path: tests/Unit/Mail/MailServiceTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Reflection/ClassNameServiceTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Reflection/ReflectionServiceTest.php
+
+		-
 			message: "#^Access to an undefined property Tests\\\\Unit\\\\Repository\\\\ActivityRepositoryTest\\:\\:\\$em\\.$#"
 			count: 3
 			path: tests/Unit/Repository/ActivityRepositoryTest.php
@@ -3414,6 +4114,16 @@ parameters:
 		-
 			message: "#^Cannot call method getMetadataFactory\\(\\) on object\\|null\\.$#"
 			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertTrue\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 2
 			path: tests/Unit/Repository/ActivityRepositoryTest.php
 
 		-
@@ -3432,6 +4142,11 @@ parameters:
 			path: tests/Unit/Repository/ActivityRepositoryTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Repository/GroupRepositoryTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\GroupRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
 			count: 1
 			path: tests/Unit/Repository/GroupRepositoryTest.php
@@ -3440,6 +4155,11 @@ parameters:
 			message: "#^Property Tests\\\\Unit\\\\Repository\\\\GroupRepositoryTest\\:\\:\\$registry \\(Doctrine\\\\Persistence\\\\ManagerRegistry\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Unit/Repository/GroupRepositoryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Repository/OptionRepositoryTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\OptionRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
@@ -3452,6 +4172,11 @@ parameters:
 			path: tests/Unit/Repository/OptionRepositoryTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 9
+			path: tests/Unit/Repository/RegistrationRepositoryTest.php
+
+		-
 			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\RegistrationRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
 			count: 1
 			path: tests/Unit/Repository/RegistrationRepositoryTest.php
@@ -3460,6 +4185,11 @@ parameters:
 			message: "#^Property Tests\\\\Unit\\\\Repository\\\\RegistrationRepositoryTest\\:\\:\\$registry \\(Doctrine\\\\Persistence\\\\ManagerRegistry\\) does not accept object\\|null\\.$#"
 			count: 1
 			path: tests/Unit/Repository/RegistrationRepositoryTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 5
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$em of class App\\\\Security\\\\LocalAuthenticator constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
@@ -3502,9 +4232,29 @@ parameters:
 			path: tests/Unit/Security/LocalAuthenticatorTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Security/LocalUserProviderTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Security/LocalUserProviderTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\TestCase\\:\\:once\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Security/LocalUserProviderTest.php
+
+		-
 			message: "#^PHPDoc tag @var contains generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: TEntityClass$#"
 			count: 2
 			path: tests/Unit/Security/LocalUserProviderTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 3
+			path: tests/Unit/Security/PasswordResetServiceTest.php
 
 		-
 			message: "#^Parameter \\#1 \\$em of class App\\\\Security\\\\PasswordResetService constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
@@ -3527,9 +4277,24 @@ parameters:
 			path: tests/Unit/Security/PasswordResetServiceTest.php
 
 		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 8
+			path: tests/Unit/Template/Annotation/MenuItemTest.php
+
+		-
 			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
 			count: 2
 			path: tests/Unit/Template/Annotation/MenuItemTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:assertSame\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Template/MenuBuilderTest.php
+
+		-
+			message: "#^Dynamic call to static method PHPUnit\\\\Framework\\\\Assert\\:\\:markTestIncomplete\\(\\)\\.$#"
+			count: 1
+			path: tests/Unit/Template/MenuBuilderTest.php
 
 		-
 			message: "#^Call to an undefined method Symfony\\\\Component\\\\Dotenv\\\\Dotenv\\:\\:bootEnv\\(\\)\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -1,0 +1,3543 @@
+parameters:
+	ignoreErrors:
+		-
+			message: "#^Cannot call method getAddress\\(\\) on App\\\\Entity\\\\Location\\\\Location\\|null\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Method App\\\\Calendar\\\\ICalProvider\\:\\:createCalendar\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Method App\\\\Calendar\\\\ICalProvider\\:\\:createEvent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Method App\\\\Calendar\\\\ICalProvider\\:\\:icalFeed\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Method App\\\\Calendar\\\\ICalProvider\\:\\:icalFeed\\(\\) has parameter \\$activities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Method App\\\\Calendar\\\\ICalProvider\\:\\:icalSingle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$description of method Jsvrcek\\\\ICS\\\\Model\\\\CalendarEvent\\:\\:setDescription\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$end of method Jsvrcek\\\\ICS\\\\Model\\\\CalendarEvent\\:\\:setEnd\\(\\) expects DateTime, DateTime\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$name of method Jsvrcek\\\\ICS\\\\Model\\\\Description\\\\Location\\:\\:setName\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$start of method Jsvrcek\\\\ICS\\\\Model\\\\CalendarEvent\\:\\:setStart\\(\\) expects DateTime, DateTime\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$summary of method Jsvrcek\\\\ICS\\\\Model\\\\CalendarEvent\\:\\:setSummary\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Parameter \\#1 \\$uid of method Jsvrcek\\\\ICS\\\\Model\\\\CalendarEvent\\:\\:setUid\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Calendar/ICalProvider.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Console\\\\Helper\\\\HelperInterface\\:\\:ask\\(\\)\\.$#"
+			count: 3
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CreateLocalAccountCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CreateLocalAccountCommand\\:\\:execute\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\CreateLocalAccountCommand\\:\\:interact\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Property App\\\\Command\\\\CreateLocalAccountCommand\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Property App\\\\Command\\\\CreateLocalAccountCommand\\:\\:\\$passwordEncoder has no type specified\\.$#"
+			count: 1
+			path: src/Command/CreateLocalAccountCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\HasLocalAccountCommand\\:\\:configure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Command/HasLocalAccountCommand.php
+
+		-
+			message: "#^Method App\\\\Command\\\\HasLocalAccountCommand\\:\\:execute\\(\\) should return int but return statement is missing\\.$#"
+			count: 1
+			path: src/Command/HasLocalAccountCommand.php
+
+		-
+			message: "#^Property App\\\\Command\\\\HasLocalAccountCommand\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/Command/HasLocalAccountCommand.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:callIcal\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:createRegisterForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:createUnregisterForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:registerAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:singleRegistrationForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:singleUnregistrationForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:unregisterAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$activity of method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:createRegisterForm\\(\\) expects App\\\\Entity\\\\Activity\\\\Activity, App\\\\Entity\\\\Activity\\\\Activity\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$activity of method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:createUnregisterForm\\(\\) expects App\\\\Entity\\\\Activity\\\\Activity, App\\\\Entity\\\\Activity\\\\Activity\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$person of method App\\\\Entity\\\\Activity\\\\Registration\\:\\:setPerson\\(\\) expects App\\\\Entity\\\\Security\\\\LocalAccount\\|null, object\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$person of method App\\\\Repository\\\\GroupRepository\\:\\:findAllFor\\(\\) expects App\\\\Entity\\\\Security\\\\LocalAccount, object given\\.$#"
+			count: 2
+			path: src/Controller/Activity/ActivityController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:createDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:imageAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:newAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:presentEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:priceEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:priceNewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:resetAmountPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:setAmountPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:persist\\(\\) expects object, App\\\\Entity\\\\Location\\\\Location\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\ActivityController\\:\\:\\$events has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\AdminController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/AdminController.php
+
+		-
+			message: "#^Call to an undefined method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:createQueryBuilder\\(\\)\\.$#"
+			count: 1
+			path: src/Controller/Admin/EventController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\EventController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/EventController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\EventController\\:\\:paginate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/EventController.php
+
+		-
+			message: "#^Parameter \\#1 \\$array_arg of function current expects array\\|object, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/EventController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\EventController\\:\\:\\$events has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/EventController.php
+
+		-
+			message: "#^Cannot access offset 'board' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Cannot call method getCanonical\\(\\) on App\\\\Entity\\\\Security\\\\LocalAccount\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Group\\\\Group\\|null\\.$#"
+			count: 3
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on App\\\\Entity\\\\Group\\\\Group\\|null\\.$#"
+			count: 2
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:createDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:createRelationDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:generateAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:generateStructure\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:generateStructure\\(\\) has parameter \\$defaultBoard with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:newAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:relationAddAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:relationDeleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:relationNewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\GroupController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\GroupController\\:\\:\\$events has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/GroupController.php
+
+		-
+			message: "#^Cannot access offset 'html' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Admin/MailController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\MailController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/MailController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\MailController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/MailController.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Admin/MailController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:handleRedirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:handleRedirect\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:newAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:reserveMoveDownAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:reserveMoveUpAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\RegistrationController\\:\\:reserveNewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$registration of method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:storeNewReserve\\(\\) expects App\\\\Entity\\\\Activity\\\\Registration, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$registration of method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:storeRegistration\\(\\) expects App\\\\Entity\\\\Activity\\\\Registration, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$route of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:generateUrl\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Admin/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:createDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:createRoleForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:newAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:rolesAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Admin\\\\SecurityController\\:\\:\\$events has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Admin/SecurityController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 3
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Cannot call method getOptions\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:createRegistrationDeleteForm\\(\\) has parameter \\$actionUrl with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:createRegistrationDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:createRegistrationEditForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:createRegistrationNewForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:createReserveNewForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:demoteReserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:handleRedirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:handleRedirect\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:handleRedirect\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:promoteReserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:registrationEdit\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:removeRegistration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:sendConfermationMail\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:sendConfermationMail\\(\\) has parameter \\$em with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:sendConfermationMail\\(\\) has parameter \\$message with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:sendConfermationMail\\(\\) has parameter \\$template with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:sendConfermationMail\\(\\) has parameter \\$title with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:storeNewReserve\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:storeRegistration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:updateRegistration\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$activity of method App\\\\Repository\\\\RegistrationRepository\\:\\:findAfter\\(\\) expects App\\\\Entity\\\\Activity\\\\Activity, App\\\\Entity\\\\Activity\\\\Activity\\|null given\\.$#"
+			count: 2
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Parameter \\#1 \\$activity of method App\\\\Repository\\\\RegistrationRepository\\:\\:findBefore\\(\\) expects App\\\\Entity\\\\Activity\\\\Activity, App\\\\Entity\\\\Activity\\\\Activity\\|null given\\.$#"
+			count: 2
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$position of method App\\\\Repository\\\\RegistrationRepository\\:\\:findAfter\\(\\) expects App\\\\Entity\\\\Order, App\\\\Entity\\\\Order\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Parameter \\#2 \\$position of method App\\\\Repository\\\\RegistrationRepository\\:\\:findBefore\\(\\) expects App\\\\Entity\\\\Order, App\\\\Entity\\\\Order\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:\\$mailer has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Helper/RegistrationHelper.php
+
+		-
+			message: "#^Cannot call method getAuthor\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:blockUnauthorisedUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:createDeleteForm\\(\\) should return Symfony\\\\Component\\\\Form\\\\Form but returns Symfony\\\\Component\\\\Form\\\\FormInterface\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:imageAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:newAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:presentEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:priceEditAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:priceNewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:resetAmountPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:setAmountPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:showAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$group of method App\\\\Controller\\\\Organise\\\\ActivityController\\:\\:blockUnauthorisedUsers\\(\\) expects App\\\\Entity\\\\Group\\\\Group, App\\\\Entity\\\\Group\\\\Group\\|null given\\.$#"
+			count: 7
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$object of method Doctrine\\\\Persistence\\\\ObjectManager\\:\\:persist\\(\\) expects object, App\\\\Entity\\\\Location\\\\Location\\|null given\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Parameter \\#1 \\$p of method Doctrine\\\\Common\\\\Collections\\\\Collection\\<mixed,mixed\\>\\:\\:exists\\(\\) expects Closure\\(mixed, mixed\\)\\: bool, Closure\\(mixed, App\\\\Entity\\\\Group\\\\Relation\\)\\: bool given\\.$#"
+			count: 1
+			path: src/Controller/Organise/ActivityController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\OrganiseController\\:\\:indexAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/OrganiseController.php
+
+		-
+			message: "#^Cannot call method getAuthor\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 3
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:blockUnauthorisedUsers\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:deleteAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:editAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:handleRedirect\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:handleRedirect\\(\\) has parameter \\$id with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:newAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:reserveMoveDownAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:reserveMoveUpAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:reserveNewAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$group of method App\\\\Controller\\\\Organise\\\\RegistrationController\\:\\:blockUnauthorisedUsers\\(\\) expects App\\\\Entity\\\\Group\\\\Group, App\\\\Entity\\\\Group\\\\Group\\|null given\\.$#"
+			count: 5
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$p of method Doctrine\\\\Common\\\\Collections\\\\Collection\\<mixed,mixed\\>\\:\\:exists\\(\\) expects Closure\\(mixed, mixed\\)\\: bool, Closure\\(mixed, App\\\\Entity\\\\Group\\\\Relation\\)\\: bool given\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$registration of method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:storeNewReserve\\(\\) expects App\\\\Entity\\\\Activity\\\\Registration, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$registration of method App\\\\Controller\\\\Helper\\\\RegistrationHelper\\:\\:storeRegistration\\(\\) expects App\\\\Entity\\\\Activity\\\\Registration, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Parameter \\#1 \\$route of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Controller\\\\AbstractController\\:\\:generateUrl\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Organise/RegistrationController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\LoginController\\:\\:login_check\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/LoginController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\LoginController\\:\\:logout\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/LoginController.php
+
+		-
+			message: "#^Cannot access offset 'email' on mixed\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\PasswordController\\:\\:handleInvalidToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\PasswordController\\:\\:handleValidToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\PasswordController\\:\\:handleValidToken\\(\\) has parameter \\$form with no type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\PasswordController\\:\\:registerAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\PasswordController\\:\\:requestAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Controller\\\\Security\\\\PasswordController\\:\\:resetAction\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Parameter \\#1 \\$email of method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setEmail\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Parameter \\#1 \\$email of method App\\\\Security\\\\LocalUserProvider\\:\\:loadUserByUsername\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Security\\\\PasswordController\\:\\:\\$passwordEncoder has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Property App\\\\Controller\\\\Security\\\\PasswordController\\:\\:\\$passwordReset has no type specified\\.$#"
+			count: 1
+			path: src/Controller/Security/PasswordController.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:getOptions\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:getRegistrations\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:isVisible\\(\\) has parameter \\$groups with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:setImage\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:setImageFile\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Activity\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Parameter \\#1 \\$func of method Doctrine\\\\Common\\\\Collections\\\\Collection\\<mixed,mixed\\>\\:\\:map\\(\\) expects Closure\\(mixed\\)\\: App\\\\Entity\\\\Group\\\\Group\\|null, Closure\\(App\\\\Entity\\\\Group\\\\Relation\\)\\: App\\\\Entity\\\\Group\\\\Group\\|null given\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$author has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$capacity has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$color has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$deadline has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$end has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$imageFile \\(Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\File\\) does not accept Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\File\\|null\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$imageUpdatedAt \\(DateTime\\) does not accept DateTimeImmutable\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$location has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$options has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$present has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$registrations has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$start has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$target has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Activity\\:\\:\\$visibleAfter has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Activity.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:getDetails\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:getRegistrations\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:setDetails\\(\\) has parameter \\$details with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$activity has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$confirmationMsg has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$details has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$price has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$registrations has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\PriceOption\\:\\:\\$target has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/PriceOption.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:getDeleteDate\\(\\) has invalid return type App\\\\Entity\\\\Activity\\\\DateTime\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:getDeleteDate\\(\\) should return App\\\\Entity\\\\Activity\\\\DateTime but returns DateTime\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:getNewDate\\(\\) has invalid return type App\\\\Entity\\\\Activity\\\\DateTime\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:getNewDate\\(\\) should return App\\\\Entity\\\\Activity\\\\DateTime but returns DateTime\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:getPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:setComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:setPresent\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Activity\\\\Registration\\:\\:setPresent\\(\\) has parameter \\$present with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$activity has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$comment has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$option has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$present has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Activity\\\\Registration\\:\\:\\$reserve_position has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Activity/Registration.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Group\\\\Group\\:\\:getChildren\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Group\\\\Group\\:\\:getRelations\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$active has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$children has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$name has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$parent has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$readonly has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$register has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$relationable has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$relations has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Group\\:\\:\\$subgroupable has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Group.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Group\\\\Relation\\:\\:getAllRelations\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Group\\\\Relation\\:\\:getChildren\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Group\\\\Relation\\:\\:getChildrenRecursive\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Relation\\:\\:\\$children has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Relation\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Relation\\:\\:\\$group has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Relation\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Relation\\:\\:\\$parent has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Group\\\\Relation\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Group/Relation.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Location\\\\Location\\:\\:\\$address has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Location/Location.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Location\\\\Location\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Location/Location.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$discr has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$meta has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$objectId has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$objectType has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Log\\\\Event\\:\\:\\$time has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Log/Event.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Mail\\\\Mail\\:\\:getRecipients\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$content has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$recipients has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$sender has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$sentAt has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Mail\\:\\:\\$title has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Mail.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Recipient\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Recipient.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Recipient\\:\\:\\$mail has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Recipient.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Mail\\\\Recipient\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Mail/Recipient.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:__construct\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:avg\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:calc\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:calc\\(\\) has parameter \\$fn with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:create\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:fromOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:fromOrder\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Order\\:\\:toOrder\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Order\\:\\:\\$data has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Order.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:__toString\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:eraseCredentials\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:getRegistrations\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:getRelations\\(\\) return type with generic interface Doctrine\\\\Common\\\\Collections\\\\Collection does not specify its types\\: TKey, T$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:getSalt\\(\\) should return string\\|null but return statement is missing\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:getUsername\\(\\) should return string but returns string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:isPasswordRequestNonExpired\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:isPasswordRequestNonExpired\\(\\) has parameter \\$ttl with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setPasswordRequestToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setPasswordRequestToken\\(\\) has parameter \\$passwordRequestToken with no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setPasswordRequestedAt\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setRoles\\(\\) has parameter \\$roles with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$auth_id\\)\\: Unexpected token \"\\$auth_id\", expected type at offset 95$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$date\\)\\: Unexpected token \"\\$date\", expected type at offset 126$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$password\\)\\: Unexpected token \"\\$password\", expected type at offset 97$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$passwordRequestToken\\)\\: Unexpected token \"\\$passwordRequestToken\", expected type at offset 85$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$roles\\)\\: Unexpected token \"\\$roles\", expected type at offset 93$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$ttl\\)\\: Unexpected token \"\\$ttl\", expected type at offset 92$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$user\\)\\: Unexpected token \"\\$user\", expected type at offset 102$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(DateTime\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 111$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(UserInterface\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 87$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\\\\\)\\: Unexpected token \"\\\\\\\\\", expected type at offset 87$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(array\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 78$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 80$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(string\\)\\: Unexpected token \"\\\\n     \\* \", expected variable at offset 82$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @param references unknown parameter\\: \\$name$#"
+			count: 2
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 118$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 121$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 125$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 128$#"
+			count: 2
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 129$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 153$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^PHPDoc tag @return has invalid value \\(\\)\\: Unexpected token \"\\\\n     \\*\", expected type at offset 73$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Parameter \\#1 \\$string of function substr expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$email has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$familyName has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$givenName has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$id has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$oidc \\(string\\) does not accept string\\|null\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$passwordRequestedAt \\(DateTime\\) does not accept DateTime\\|null\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$registrations has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$relations has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Property App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:\\$roles has no type specified\\.$#"
+			count: 1
+			path: src/Entity/Security/LocalAccount.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\DoctrineTablePrefixListener\\:\\:__construct\\(\\) has parameter \\$prefix with no type specified\\.$#"
+			count: 1
+			path: src/EventListener/DoctrineTablePrefixListener.php
+
+		-
+			message: "#^Method App\\\\EventListener\\\\DoctrineTablePrefixListener\\:\\:loadClassMetadata\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/EventListener/DoctrineTablePrefixListener.php
+
+		-
+			message: "#^Property App\\\\EventListener\\\\DoctrineTablePrefixListener\\:\\:\\$prefix has no type specified\\.$#"
+			count: 1
+			path: src/EventListener/DoctrineTablePrefixListener.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityCountPresent\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityCountPresent.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityCountPresent\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityCountPresent.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityEditPresent\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityEditPresent.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityEditPresent\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityEditPresent.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityEditType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityEditType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityImageType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityImageType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityImageType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityImageType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivityNewType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivityNewType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivitySetPresentAmount\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivitySetPresentAmount.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\ActivitySetPresentAmount\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/ActivitySetPresentAmount.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\Admin\\\\ActivityEditType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/Admin/ActivityEditType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\Admin\\\\ActivityEditType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/Admin/ActivityEditType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\Admin\\\\ActivityNewType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/Admin/ActivityNewType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\Admin\\\\ActivityNewType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/Admin/ActivityNewType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\PresentType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/PresentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\PresentType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/PresentType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\PriceOptionType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/PriceOptionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\PriceOptionType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/PriceOptionType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\RegistrationEditType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/RegistrationEditType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\RegistrationEditType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/RegistrationEditType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\RegistrationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/RegistrationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Activity\\\\RegistrationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Activity/RegistrationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Group\\\\GroupType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Group/GroupType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Group\\\\GroupType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Group/GroupType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Group\\\\RelationAddType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Group/RelationAddType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Group\\\\RelationAddType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Group/RelationAddType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Group\\\\RelationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Group/RelationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Group\\\\RelationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Group/RelationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Location\\\\LocationType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Location/LocationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Location\\\\LocationType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Location/LocationType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Security\\\\LocalAccountType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Security/LocalAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Security\\\\LocalAccountType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Security/LocalAccountType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Security\\\\NewPasswordType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Security/NewPasswordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Security\\\\NewPasswordType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Security/NewPasswordType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Security\\\\PasswordRequestType\\:\\:buildForm\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Security/PasswordRequestType.php
+
+		-
+			message: "#^Method App\\\\Form\\\\Security\\\\PasswordRequestType\\:\\:configureOptions\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Form/Security/PasswordRequestType.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Query\\:\\:activities\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Query\\:\\:current\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Query\\:\\:groups\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Query\\:\\:user\\(\\) should return App\\\\Entity\\\\Security\\\\LocalAccount\\|null but returns object\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Query\\:\\:users\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Property App\\\\GraphQL\\\\Query\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Property App\\\\GraphQL\\\\Query\\:\\:\\$tokenStorage has no type specified\\.$#"
+			count: 1
+			path: src/GraphQL/Query.php
+
+		-
+			message: "#^Access to an undefined property GraphQL\\\\Language\\\\AST\\\\Node\\:\\:\\$value\\.$#"
+			count: 1
+			path: src/GraphQL/Types/DatetimeScalar.php
+
+		-
+			message: "#^Method App\\\\GraphQL\\\\Types\\\\DatetimeScalar\\:\\:parseLiteral\\(\\) should return string but returns DateTime\\.$#"
+			count: 1
+			path: src/GraphQL/Types/DatetimeScalar.php
+
+		-
+			message: "#^Parameter \\#1 \\$datetime of class DateTime constructor expects string, mixed given\\.$#"
+			count: 1
+			path: src/GraphQL/Types/DatetimeScalar.php
+
+		-
+			message: "#^Method App\\\\Group\\\\GroupMenuExtension\\:\\:discoverMenuItems\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Group/GroupMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Group\\\\GroupMenuExtension\\:\\:getMenuItems\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Group/GroupMenuExtension.php
+
+		-
+			message: "#^Property App\\\\Group\\\\GroupMenuExtension\\:\\:\\$menuItems is never read, only written\\.$#"
+			count: 1
+			path: src/Group/GroupMenuExtension.php
+
+		-
+			message: "#^Property App\\\\Group\\\\GroupMenuExtension\\:\\:\\$menuItems type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Group/GroupMenuExtension.php
+
+		-
+			message: "#^Unreachable statement \\- code above always terminates\\.$#"
+			count: 1
+			path: src/Group/GroupMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Group\\\\OrganiseMenuExtension\\:\\:discoverMenuItems\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Group/OrganiseMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Group\\\\OrganiseMenuExtension\\:\\:getMenuItems\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Group/OrganiseMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Group\\\\OrganiseMenuExtension\\:\\:getUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Group/OrganiseMenuExtension.php
+
+		-
+			message: "#^Property App\\\\Group\\\\OrganiseMenuExtension\\:\\:\\$menuItems type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Group/OrganiseMenuExtension.php
+
+		-
+			message: "#^Generator expects value type Symfony\\\\Component\\\\HttpKernel\\\\Bundle\\\\BundleInterface, object given\\.$#"
+			count: 1
+			path: src/Kernel.php
+
+		-
+			message: "#^Method App\\\\Kernel\\:\\:build\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Kernel.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:getEntity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:getEntityType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:getPerson\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:getTime\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:getTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:setEntity\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:setEntity\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:setEntityType\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\AbstractEvent\\:\\:setEntityType\\(\\) has parameter \\$type with no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$entity has no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$entityCb has no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$entityType has no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$person is never written, only read\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$time has no type specified\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\AbstractEvent\\:\\:\\$time is never written, only read\\.$#"
+			count: 1
+			path: src/Log/AbstractEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:extractFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:extractFields\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:extractFields\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:onFlush\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:sanitize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:sanitize\\(\\) has parameter \\$field with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:sanitize\\(\\) has parameter \\$metadata with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:sanitize\\(\\) has parameter \\$value with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Parameter \\#1 \\$className of method Doctrine\\\\ORM\\\\EntityManager\\:\\:getClassMetadata\\(\\) expects string, class\\-string\\|false given\\.$#"
+			count: 4
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:\\$eventService has no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:\\$reflService has no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityEventListener\\:\\:\\$reflService is never read, only written\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityEventListener.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:__construct\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:__construct\\(\\) has parameter \\$fields with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:getFields\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:getTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:\\$fields has no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:\\$type has no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityNewEvent\\:\\:\\$type is unused\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityNewEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:__construct\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:__construct\\(\\) has parameter \\$newValues with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:__construct\\(\\) has parameter \\$oldObject with no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:getNew\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:getNewChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:getOld\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:getOldChanged\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Method App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:getTitle\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:\\$new has no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Property App\\\\Log\\\\Doctrine\\\\EntityUpdateEvent\\:\\:\\$old has no type specified\\.$#"
+			count: 1
+			path: src/Log/Doctrine/EntityUpdateEvent.php
+
+		-
+			message: "#^Cannot access offset 'entityCb' on mixed\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Cannot access offset 'entityType' on mixed\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Cannot access offset 'person' on mixed\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Cannot access offset 'time' on mixed\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:findBy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:findBy\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:findBy\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:findOneBy\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:findOneBy\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:findOneBy\\(\\) has parameter \\$options with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:getClassName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:getClassName\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:getIdentifier\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:getIdentifier\\(\\) has parameter \\$entity with no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:hydrate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:log\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:populate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:populateAll\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Log\\\\EventService\\:\\:populateAll\\(\\) has parameter \\$entities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Parameter \\#1 \\$classname of function class_exists expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Parameter \\#1 \\$variable_representation of function unserialize expects string, string\\|null given\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Property App\\\\Log\\\\EventService\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Property App\\\\Log\\\\EventService\\:\\:\\$person has no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Property App\\\\Log\\\\EventService\\:\\:\\$refl has no type specified\\.$#"
+			count: 1
+			path: src/Log/EventService.php
+
+		-
+			message: "#^Method App\\\\Mail\\\\MailService\\:\\:getUser\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Method App\\\\Mail\\\\MailService\\:\\:message\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Method App\\\\Mail\\\\MailService\\:\\:message\\(\\) has parameter \\$attachments with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Method App\\\\Mail\\\\MailService\\:\\:message\\(\\) has parameter \\$to with no type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method App\\\\Entity\\\\Mail\\\\Mail\\:\\:setContent\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Property App\\\\Mail\\\\MailService\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Property App\\\\Mail\\\\MailService\\:\\:\\$mailer has no type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Property App\\\\Mail\\\\MailService\\:\\:\\$params has no type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Property App\\\\Mail\\\\MailService\\:\\:\\$tokenStorage has no type specified\\.$#"
+			count: 1
+			path: src/Mail/MailService.php
+
+		-
+			message: "#^Method App\\\\Reflection\\\\ClassNameService\\:\\:fqcnToName\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Reflection/ClassNameService.php
+
+		-
+			message: "#^Method App\\\\Reflection\\\\ClassNameService\\:\\:fqcnToName\\(\\) has parameter \\$fqcn with no type specified\\.$#"
+			count: 1
+			path: src/Reflection/ClassNameService.php
+
+		-
+			message: "#^Method App\\\\Reflection\\\\ReflectionService\\:\\:getAllProperties\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Reflection/ReflectionService.php
+
+		-
+			message: "#^Method App\\\\Reflection\\\\ReflectionService\\:\\:instantiate\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Reflection/ReflectionService.php
+
+		-
+			message: "#^Method App\\\\Reflection\\\\ReflectionService\\:\\:instantiate\\(\\) has parameter \\$fieldValues with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Reflection/ReflectionService.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 1
+			path: src/Reflection/ReflectionService.php
+
+		-
+			message: "#^Property App\\\\Reflection\\\\ReflectionService\\:\\:\\$instantiator has no type specified\\.$#"
+			count: 1
+			path: src/Reflection/ReflectionService.php
+
+		-
+			message: "#^Class App\\\\Repository\\\\ActivityRepository extends generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: TEntityClass$#"
+			count: 1
+			path: src/Repository/ActivityRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\ActivityRepository\\:\\:findUpcoming\\(\\) should return array\\<App\\\\Entity\\\\Activity\\\\Activity\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/ActivityRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\ActivityRepository\\:\\:findUpcomingByGroup\\(\\) has parameter \\$groups with no type specified\\.$#"
+			count: 1
+			path: src/Repository/ActivityRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\ActivityRepository\\:\\:findUpcomingByGroup\\(\\) should return array\\<App\\\\Entity\\\\Activity\\\\Activity\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/ActivityRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\ActivityRepository\\:\\:findVisibleUpcomingByGroup\\(\\) has parameter \\$groups with no type specified\\.$#"
+			count: 1
+			path: src/Repository/ActivityRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\ActivityRepository\\:\\:findVisibleUpcomingByGroup\\(\\) should return array\\<App\\\\Entity\\\\Activity\\\\Activity\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/ActivityRepository.php
+
+		-
+			message: "#^Class App\\\\Repository\\\\GroupRepository extends generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: TEntityClass$#"
+			count: 1
+			path: src/Repository/GroupRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\GroupRepository\\:\\:findAllFor\\(\\) should return array\\<App\\\\Entity\\\\Group\\\\Group\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/GroupRepository.php
+
+		-
+			message: "#^Class App\\\\Repository\\\\OptionRepository extends generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: TEntityClass$#"
+			count: 1
+			path: src/Repository/OptionRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\OptionRepository\\:\\:findUpcomingByGroup\\(\\) has parameter \\$groups with no type specified\\.$#"
+			count: 1
+			path: src/Repository/OptionRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\OptionRepository\\:\\:findUpcomingByGroup\\(\\) should return array\\<App\\\\Entity\\\\Activity\\\\PriceOption\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/OptionRepository.php
+
+		-
+			message: "#^Cannot call method getReservePosition\\(\\) on mixed\\.$#"
+			count: 4
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Class App\\\\Repository\\\\RegistrationRepository extends generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: TEntityClass$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:MAXORDER\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:MINORDER\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:countPresent\\(\\) should return int but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:findAfter\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:findAppendPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:findBefore\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:findDeregistrations\\(\\) should return array\\<App\\\\Entity\\\\Activity\\\\Registration\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:findPrependPosition\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Method App\\\\Repository\\\\RegistrationRepository\\:\\:findReserve\\(\\) should return array\\<App\\\\Entity\\\\Activity\\\\Registration\\> but returns mixed\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Property App\\\\Repository\\\\RegistrationRepository\\:\\:\\$max has no type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Property App\\\\Repository\\\\RegistrationRepository\\:\\:\\$min has no type specified\\.$#"
+			count: 1
+			path: src/Repository/RegistrationRepository.php
+
+		-
+			message: "#^Cannot access offset 'csrf_token' on mixed\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Cannot access offset 'password' on mixed\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Cannot access offset 'username' on mixed\\.$#"
+			count: 2
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Cannot call method getMessage\\(\\) on mixed\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Negated boolean expression is always false\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Parameter \\#1 \\$str of function trim expects string, mixed given\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Parameter \\#1 \\$username of method Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserProviderInterface\\:\\:loadUserByUsername\\(\\) expects string, mixed given\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Parameter \\#2 \\$value of class Symfony\\\\Component\\\\Security\\\\Csrf\\\\CsrfToken constructor expects string\\|null, mixed given\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\LocalAuthenticator\\:\\:\\$csrfTokenManager has no type specified\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\LocalAuthenticator\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\LocalAuthenticator\\:\\:\\$em is never read, only written\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\LocalAuthenticator\\:\\:\\$passwordEncoder has no type specified\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\LocalAuthenticator\\:\\:\\$urlGenerator has no type specified\\.$#"
+			count: 1
+			path: src/Security/LocalAuthenticator.php
+
+		-
+			message: "#^Property App\\\\Security\\\\LocalUserProvider\\:\\:\\$em has no type specified\\.$#"
+			count: 1
+			path: src/Security/LocalUserProvider.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Security\\\\PasswordResetService\\:\\:\\$em\\.$#"
+			count: 5
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Access to an undefined property App\\\\Security\\\\PasswordResetService\\:\\:\\$encoderFactory\\.$#"
+			count: 4
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\SelfSaltingEncoderInterface\\:\\:encodePassword\\(\\)\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\SelfSaltingEncoderInterface\\:\\:isPasswordValid\\(\\)\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Method App\\\\Entity\\\\Security\\\\LocalAccount\\:\\:setPasswordRequestSalt\\(\\) invoked with 1 parameter, 0 required\\.$#"
+			count: 2
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Method App\\\\Security\\\\PasswordResetService\\:\\:generatePasswordRequestToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Method App\\\\Security\\\\PasswordResetService\\:\\:isPasswordRequestTokenValid\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Method App\\\\Security\\\\PasswordResetService\\:\\:resetPasswordRequestToken\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Property App\\\\Security\\\\PasswordResetService\\:\\:\\$managerName has no type specified\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Property App\\\\Security\\\\PasswordResetService\\:\\:\\$managerName is unused\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Property App\\\\Security\\\\PasswordResetService\\:\\:\\$registry has no type specified\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Property App\\\\Security\\\\PasswordResetService\\:\\:\\$registry is unused\\.$#"
+			count: 1
+			path: src/Security/PasswordResetService.php
+
+		-
+			message: "#^Method App\\\\Template\\\\Annotation\\\\MenuItem\\:\\:getPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Template/Annotation/MenuItem.php
+
+		-
+			message: "#^Method App\\\\Template\\\\Annotation\\\\MenuItem\\:\\:setPath\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Template/Annotation/MenuItem.php
+
+		-
+			message: "#^Method App\\\\Template\\\\Annotation\\\\MenuItem\\:\\:setPath\\(\\) has parameter \\$path with no type specified\\.$#"
+			count: 1
+			path: src/Template/Annotation/MenuItem.php
+
+		-
+			message: "#^Method App\\\\Template\\\\AnnotationMenuExtension\\:\\:__construct\\(\\) has parameter \\$directory with no type specified\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Template\\\\AnnotationMenuExtension\\:\\:__construct\\(\\) has parameter \\$namespace with no type specified\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Template\\\\AnnotationMenuExtension\\:\\:__construct\\(\\) has parameter \\$rootDir with no type specified\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Template\\\\AnnotationMenuExtension\\:\\:discoverMenuItems\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Template\\\\AnnotationMenuExtension\\:\\:getMenuItems\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: """
+				#^PHPDoc tag @param has invalid value \\(\\$directory
+				  The directory of the menu items\\)\\: Unexpected token "\\$directory", expected type at offset 125$#
+			"""
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: """
+				#^PHPDoc tag @param has invalid value \\(\\$namespace
+				  The namespace of the menu items\\)\\: Unexpected token "\\$namespace", expected type at offset 59$#
+			"""
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^PHPDoc tag @param has invalid value \\(\\$rootDir\\)\\: Unexpected token \"\\$rootDir\", expected type at offset 191$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Property App\\\\Template\\\\AnnotationMenuExtension\\:\\:\\$menuItems type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Template/AnnotationMenuExtension.php
+
+		-
+			message: "#^Method App\\\\Template\\\\MenuBuilder\\:\\:__construct\\(\\) has parameter \\$extensions with no type specified\\.$#"
+			count: 1
+			path: src/Template/MenuBuilder.php
+
+		-
+			message: "#^Method App\\\\Template\\\\MenuBuilder\\:\\:getItems\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Template/MenuBuilder.php
+
+		-
+			message: "#^Property App\\\\Template\\\\MenuBuilder\\:\\:\\$extensions has no type specified\\.$#"
+			count: 1
+			path: src/Template/MenuBuilder.php
+
+		-
+			message: "#^Property App\\\\Template\\\\MenuBuilder\\:\\:\\$menuitems has no type specified\\.$#"
+			count: 1
+			path: src/Template/MenuBuilder.php
+
+		-
+			message: "#^Method App\\\\Template\\\\MenuExtensionInterface\\:\\:getMenuItems\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Template/MenuExtensionInterface.php
+
+		-
+			message: "#^Cannot call method get\\(\\) on Symfony\\\\Component\\\\DependencyInjection\\\\ContainerInterface\\|null\\.$#"
+			count: 3
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method getMetadataFactory\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method getName\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method invalidate\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method save\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method set\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Cannot call method setToken\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class Doctrine\\\\ORM\\\\Tools\\\\SchemaTool constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: src/Tests/AuthWebTestCase.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\ActivityFixture\\:\\:generate\\(\\) has parameter \\$locations with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/ActivityFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\ActivityFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/ActivityFixture.php
+
+		-
+			message: "#^Parameter \\#2 \\$group of static method App\\\\Tests\\\\Database\\\\Activity\\\\ActivityFixture\\:\\:generate\\(\\) expects App\\\\Entity\\\\Group\\\\Group, object given\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/ActivityFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\PriceOptionFixture\\:\\:generate\\(\\) has parameter \\$activities with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/PriceOptionFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\PriceOptionFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/PriceOptionFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\RegistrationFixture\\:\\:generate\\(\\) has parameter \\$activity with no type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/RegistrationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\RegistrationFixture\\:\\:generate\\(\\) has parameter \\$person with no type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/RegistrationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\RegistrationFixture\\:\\:generate\\(\\) has parameter \\$priceOption with no type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/RegistrationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Activity\\\\RegistrationFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Activity/RegistrationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Group\\\\GroupFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Group/GroupFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Group\\\\RelationFixture\\:\\:generate\\(\\) has parameter \\$group with no type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Group/RelationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Group\\\\RelationFixture\\:\\:generate\\(\\) has parameter \\$person with no type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Group/RelationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Group\\\\RelationFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Group/RelationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Location\\\\LocationFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Location/LocationFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Mail\\\\MailFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Mail/MailFixture.php
+
+		-
+			message: "#^Parameter \\#1 \\$content of method App\\\\Entity\\\\Mail\\\\Mail\\:\\:setContent\\(\\) expects string, string\\|false given\\.$#"
+			count: 1
+			path: src/Tests/Database/Mail/MailFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\Database\\\\Security\\\\LocalAccountFixture\\:\\:load\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Security/LocalAccountFixture.php
+
+		-
+			message: "#^Property App\\\\Tests\\\\Database\\\\Security\\\\LocalAccountFixture\\:\\:\\$encoder has no type specified\\.$#"
+			count: 1
+			path: src/Tests/Database/Security/LocalAccountFixture.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:__construct\\(\\) has parameter \\$initial with no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:allConditionsSucceed\\(\\) has parameter \\$object with no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:buildFromData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:buildFromData\\(\\) has parameter \\$data with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:buildPermutations\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:cartesian\\(\\) has parameter \\$set with no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:cartesian\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:doWith\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:from\\(\\) has parameter \\$object with no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:return\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:returnInvalid\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method App\\\\Tests\\\\TestData\\:\\:with\\(\\) has parameter \\$options with no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^PHPDoc tag @throws with type App\\\\Tests\\\\UnexpectedValueException is not subtype of Throwable$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Parameter \\#1 \\$argument of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Property App\\\\Tests\\\\TestData\\:\\:\\$action_options has no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Property App\\\\Tests\\\\TestData\\:\\:\\$conditions has no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Property App\\\\Tests\\\\TestData\\:\\:\\$initial has no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Property App\\\\Tests\\\\TestData\\:\\:\\$property_options has no type specified\\.$#"
+			count: 1
+			path: src/Tests/TestData.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\Command\\\\CreateLocalAccountCommandTest\\:\\:testExecute\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\Command\\\\CreateLocalAccountCommandTest\\:\\:testInteract\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Command\\\\CreateLocalAccountCommandTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Command/CreateLocalAccountCommandTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\Command\\\\HasLocalAccountCommandTest\\:\\:testExecuteEmpty\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Functional/Command/HasLocalAccountCommandTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\Command\\\\HasLocalAccountCommandTest\\:\\:testExecuteWithFixtures\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Functional/Command/HasLocalAccountCommandTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Command\\\\HasLocalAccountCommandTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Command/HasLocalAccountCommandTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Functional\\\\Controller\\\\Activity\\\\ActivityControllerTest\\:\\:\\$em\\.$#"
+			count: 9
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Activity/ActivityControllerTest.php
+
+		-
+			message: "#^Cannot call method setValue\\(\\) on array\\<array\\<Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\>\\|Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\>\\|Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$events of class App\\\\Controller\\\\Admin\\\\ActivityController constructor expects App\\\\Log\\\\EventService, object\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Parameter \\#5 \\$test of class Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\UploadedFile constructor expects bool, null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\ActivityControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\ActivityControllerTest\\:\\:\\$events \\(App\\\\Log\\\\EventService\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Symfony\\\\Component\\\\DomCrawler\\\\Form does not accept Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\UploadedFile\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Symfony\\\\Component\\\\DomCrawler\\\\Form does not accept int\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/ActivityControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$events of class App\\\\Controller\\\\Admin\\\\EventController constructor expects App\\\\Log\\\\EventService, object\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/EventControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\EventControllerTest\\:\\:\\$events \\(App\\\\Log\\\\EventService\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/EventControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\GroupControllerTest\\:\\:\\$controllerEndpoint has no type specified\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\GroupControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/GroupControllerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$text of method Symfony\\\\Bundle\\\\FrameworkBundle\\\\Test\\\\WebTestCase\\:\\:assertSelectorTextContains\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/MailControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\MailControllerTest\\:\\:\\$controllerEndpoint has no type specified\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/MailControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\MailControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/MailControllerTest.php
+
+		-
+			message: "#^Cannot call method getComment\\(\\) on App\\\\Entity\\\\Activity\\\\Registration\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Cannot call method getDeleteDate\\(\\) on App\\\\Entity\\\\Activity\\\\Registration\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Cannot call method getRegistrations\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\RegistrationControllerTest\\:\\:\\$controller has no type specified\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\RegistrationControllerTest\\:\\:\\$controller is never read, only written\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Admin\\\\RegistrationControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/RegistrationControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Functional\\\\Controller\\\\Admin\\\\SecurityControllerTest\\:\\:\\$em\\.$#"
+			count: 3
+			path: tests/Functional/Controller/Admin/SecurityControllerTest.php
+
+		-
+			message: "#^Cannot call method setValue\\(\\) on array\\<array\\<Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\>\\|Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\>\\|Symfony\\\\Component\\\\DomCrawler\\\\Field\\\\FormField\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Admin/SecurityControllerTest.php
+
+		-
+			message: "#^Cannot call method getComment\\(\\) on App\\\\Entity\\\\Activity\\\\Registration\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Cannot call method getDeleteDate\\(\\) on App\\\\Entity\\\\Activity\\\\Registration\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on App\\\\Entity\\\\Group\\\\Group\\|null\\.$#"
+			count: 8
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Cannot call method getId\\(\\) on mixed\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Cannot call method getRegistrations\\(\\) on App\\\\Entity\\\\Activity\\\\Activity\\|null\\.$#"
+			count: 2
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Organise\\\\RegistrationControllerTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Organise/RegistrationControllerTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\Controller\\\\Security\\\\LoginControllerTest\\:\\:setupOidc\\(\\) has parameter \\$container with no type specified\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/LoginControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/LoginControllerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$haystack of method PHPUnit\\\\Framework\\\\Assert\\:\\:assertStringContainsString\\(\\) expects string, string\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/LoginControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Functional\\\\Controller\\\\Security\\\\PasswordControllerTest\\:\\:\\$em\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Functional\\\\Controller\\\\Security\\\\PasswordControllerTest\\:\\:\\$userProvider\\.$#"
+			count: 5
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class App\\\\Security\\\\LocalUserProvider constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$passwordEncoder of class App\\\\Controller\\\\Security\\\\PasswordController constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\UserPasswordEncoderInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$passwordReset of class App\\\\Controller\\\\Security\\\\PasswordController constructor expects App\\\\Security\\\\PasswordResetService, object\\|null given\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Security\\\\PasswordControllerTest\\:\\:\\$passwordEncoder \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\UserPasswordEncoderInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Property Tests\\\\Functional\\\\Controller\\\\Security\\\\PasswordControllerTest\\:\\:\\$passwordReset \\(App\\\\Security\\\\PasswordResetService\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Functional/Controller/Security/PasswordControllerTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\GraphQL\\\\QueryTest\\:\\:graphqlQuery\\(\\) has parameter \\$variables with no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\GraphQL\\\\QueryTest\\:\\:graphqlQuery\\(\\) return type has no value type specified in iterable type array\\.$#"
+			count: 1
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Method Tests\\\\Functional\\\\GraphQL\\\\QueryTest\\:\\:graphqlQuery\\(\\) should return array but returns mixed\\.$#"
+			count: 1
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$json of function json_decode expects string, string\\|false given\\.$#"
+			count: 1
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Parameter \\#6 \\$content of method Symfony\\\\Component\\\\BrowserKit\\\\Client\\:\\:request\\(\\) expects string\\|null, string\\|false given\\.$#"
+			count: 1
+			path: tests/Functional/GraphQL/QueryTest.php
+
+		-
+			message: "#^Cannot call method create\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityEditTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Integration\\\\Form\\\\Activity\\\\Admin\\\\ActivityEditTypeTest\\:\\:testBindValidData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityEditTypeTest.php
+
+		-
+			message: "#^Cannot call method create\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityNewTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Integration\\\\Form\\\\Activity\\\\Admin\\\\ActivityNewTypeTest\\:\\:testBindValidData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityNewTypeTest.php
+
+		-
+			message: "#^Parameter \\#5 \\$test of class Symfony\\\\Component\\\\HttpFoundation\\\\File\\\\UploadedFile constructor expects bool, null given\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/Admin/ActivityNewTypeTest.php
+
+		-
+			message: "#^Cannot call method create\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/PresentTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Integration\\\\Form\\\\Activity\\\\PresentTypeTest\\:\\:testBindValidData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/PresentTypeTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Integration\\\\Form\\\\Activity\\\\RegistrationEditTypeTest\\:\\:\\$registerationedittype\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/RegistrationEditTypeTest.php
+
+		-
+			message: "#^Cannot call method create\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/RegistrationEditTypeTest.php
+
+		-
+			message: "#^Method Tests\\\\Integration\\\\Form\\\\Activity\\\\RegistrationEditTypeTest\\:\\:testBindValidData\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/RegistrationEditTypeTest.php
+
+		-
+			message: "#^Class App\\\\Form\\\\Activity\\\\RegistrationType does not have a constructor and must be instantiated without any parameters\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/RegistrationTypeTest.php
+
+		-
+			message: "#^Property Tests\\\\Integration\\\\Form\\\\Activity\\\\RegistrationTypeTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Integration/Form/Activity/RegistrationTypeTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Integration\\\\Form\\\\Group\\\\RelationTypeTest\\:\\:\\$relationType\\.$#"
+			count: 1
+			path: tests/Integration/Form/Group/RelationTypeTest.php
+
+		-
+			message: "#^Cannot call method format\\(\\) on DateTime\\|null\\.$#"
+			count: 2
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Calendar\\\\ICalProviderTest\\:\\:\\$description has no type specified\\.$#"
+			count: 1
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Calendar\\\\ICalProviderTest\\:\\:\\$invalidActivity has no type specified\\.$#"
+			count: 1
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Calendar\\\\ICalProviderTest\\:\\:\\$now \\(Tests\\\\Unit\\\\Calendar\\\\datetime\\) does not accept DateTime\\.$#"
+			count: 1
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Calendar\\\\ICalProviderTest\\:\\:\\$now has unknown class Tests\\\\Unit\\\\Calendar\\\\datetime as its type\\.$#"
+			count: 1
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Calendar\\\\ICalProviderTest\\:\\:\\$secondActivity has no type specified\\.$#"
+			count: 1
+			path: tests/Unit/Calendar/ICalProviderTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^PHPDoc tag @var contains unknown class Tests\\\\Unit\\\\Entity\\\\Activity\\\\MockObject\\.$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^You should use assertFalse\\(\\) instead of assertSame\\(\\) when expecting \"false\"$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^You should use assertTrue\\(\\) instead of assertSame\\(\\) when expecting \"true\"$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/ActivityTest.php
+
+		-
+			message: "#^Cannot access offset 0 on mixed\\.$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/PriceOptionTest.php
+
+		-
+			message: "#^Method Tests\\\\Unit\\\\Entity\\\\Activity\\\\RegistrationTest\\:\\:testGetComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/RegistrationTest.php
+
+		-
+			message: "#^Method Tests\\\\Unit\\\\Entity\\\\Activity\\\\RegistrationTest\\:\\:testSetComment\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/RegistrationTest.php
+
+		-
+			message: "#^You should use assertFalse\\(\\) instead of assertSame\\(\\) when expecting \"false\"$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/RegistrationTest.php
+
+		-
+			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
+			count: 3
+			path: tests/Unit/Entity/Activity/RegistrationTest.php
+
+		-
+			message: "#^You should use assertTrue\\(\\) instead of assertSame\\(\\) when expecting \"true\"$#"
+			count: 1
+			path: tests/Unit/Entity/Activity/RegistrationTest.php
+
+		-
+			message: "#^You should use assertTrue\\(\\) instead of assertSame\\(\\) when expecting \"true\"$#"
+			count: 9
+			path: tests/Unit/Entity/Group/GroupTest.php
+
+		-
+			message: "#^Cannot call method add\\(\\) on mixed\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
+			count: 2
+			path: tests/Unit/Entity/Security/LocalAccountTest.php
+
+		-
+			message: "#^Method Tests\\\\Unit\\\\GraphQL\\\\Types\\\\DatetimeScalarTest\\:\\:testParseLiteral\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Unit/GraphQL/Types/DatetimeScalarTest.php
+
+		-
+			message: "#^Method Tests\\\\Unit\\\\GraphQL\\\\Types\\\\DatetimeScalarTest\\:\\:testParseValue\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Unit/GraphQL/Types/DatetimeScalarTest.php
+
+		-
+			message: "#^Method Tests\\\\Unit\\\\GraphQL\\\\Types\\\\DatetimeScalarTest\\:\\:testSerialize\\(\\) has no return type specified\\.$#"
+			count: 1
+			path: tests/Unit/GraphQL/Types/DatetimeScalarTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class App\\\\Group\\\\GroupMenuExtension constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Group/GroupMenuExtensionTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Group\\\\GroupMenuExtensionTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Group/GroupMenuExtensionTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class App\\\\Group\\\\OrganiseMenuExtension constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Group/OrganiseMenuExtensionTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$tokenStorage of class App\\\\Group\\\\OrganiseMenuExtension constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorageInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Group/OrganiseMenuExtensionTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Group\\\\OrganiseMenuExtensionTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Group/OrganiseMenuExtensionTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Group\\\\OrganiseMenuExtensionTest\\:\\:\\$tokenStorage \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorageInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Group/OrganiseMenuExtensionTest.php
+
+		-
+			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
+			count: 1
+			path: tests/Unit/Log/AbstractEventTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$eventService of class App\\\\Log\\\\Doctrine\\\\EntityEventListener constructor expects App\\\\Log\\\\EventService, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Log/Doctrine/EntityEventListenerTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$reflService of class App\\\\Log\\\\Doctrine\\\\EntityEventListener constructor expects App\\\\Reflection\\\\ReflectionService, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Log/Doctrine/EntityEventListenerTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Log\\\\Doctrine\\\\EntityEventListenerTest\\:\\:\\$eventService \\(App\\\\Log\\\\EventService\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Log/Doctrine/EntityEventListenerTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Log\\\\Doctrine\\\\EntityEventListenerTest\\:\\:\\$reflService \\(App\\\\Reflection\\\\ReflectionService\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Log/Doctrine/EntityEventListenerTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class App\\\\Log\\\\EventService constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Log/EventServiceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$tokenStorage of class App\\\\Log\\\\EventService constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorageInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Log/EventServiceTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$refl of class App\\\\Log\\\\EventService constructor expects App\\\\Reflection\\\\ReflectionService, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Log/EventServiceTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Log\\\\EventServiceTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Log/EventServiceTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Log\\\\EventServiceTest\\:\\:\\$refl \\(App\\\\Reflection\\\\ReflectionService\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Log/EventServiceTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Log\\\\EventServiceTest\\:\\:\\$tokenStorage \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Authentication\\\\Token\\\\Storage\\\\TokenStorageInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Log/EventServiceTest.php
+
+		-
+			message: "#^Access to an undefined property Tests\\\\Unit\\\\Repository\\\\ActivityRepositoryTest\\:\\:\\$em\\.$#"
+			count: 3
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Cannot call method getManager\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Cannot call method getMetadataFactory\\(\\) on object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class Doctrine\\\\ORM\\\\Tools\\\\SchemaTool constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\ActivityRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Repository\\\\ActivityRepositoryTest\\:\\:\\$registry \\(Doctrine\\\\Persistence\\\\ManagerRegistry\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Repository/ActivityRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\GroupRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Repository/GroupRepositoryTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Repository\\\\GroupRepositoryTest\\:\\:\\$registry \\(Doctrine\\\\Persistence\\\\ManagerRegistry\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Repository/GroupRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\OptionRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Repository/OptionRepositoryTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Repository\\\\OptionRepositoryTest\\:\\:\\$registry \\(Doctrine\\\\Persistence\\\\ManagerRegistry\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Repository/OptionRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$registry of class App\\\\Repository\\\\RegistrationRepository constructor expects Doctrine\\\\Persistence\\\\ManagerRegistry, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Repository/RegistrationRepositoryTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Repository\\\\RegistrationRepositoryTest\\:\\:\\$registry \\(Doctrine\\\\Persistence\\\\ManagerRegistry\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Repository/RegistrationRepositoryTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class App\\\\Security\\\\LocalAuthenticator constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$urlGenerator of class App\\\\Security\\\\LocalAuthenticator constructor expects Symfony\\\\Component\\\\Routing\\\\Generator\\\\UrlGeneratorInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Parameter \\#3 \\$csrfTokenManager of class App\\\\Security\\\\LocalAuthenticator constructor expects Symfony\\\\Component\\\\Security\\\\Csrf\\\\CsrfTokenManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Parameter \\#4 \\$passwordEncoder of class App\\\\Security\\\\LocalAuthenticator constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\UserPasswordEncoderInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Security\\\\LocalAuthenticatorTest\\:\\:\\$csrfTokenManager \\(Symfony\\\\Component\\\\Security\\\\Csrf\\\\CsrfTokenManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Security\\\\LocalAuthenticatorTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Security\\\\LocalAuthenticatorTest\\:\\:\\$passwordEncoder \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\UserPasswordEncoderInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Security\\\\LocalAuthenticatorTest\\:\\:\\$urlGenerator \\(Symfony\\\\Component\\\\Routing\\\\Generator\\\\UrlGeneratorInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Security/LocalAuthenticatorTest.php
+
+		-
+			message: "#^PHPDoc tag @var contains generic class Doctrine\\\\Bundle\\\\DoctrineBundle\\\\Repository\\\\ServiceEntityRepository but does not specify its types\\: TEntityClass$#"
+			count: 2
+			path: tests/Unit/Security/LocalUserProviderTest.php
+
+		-
+			message: "#^Parameter \\#1 \\$em of class App\\\\Security\\\\PasswordResetService constructor expects Doctrine\\\\ORM\\\\EntityManagerInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Security/PasswordResetServiceTest.php
+
+		-
+			message: "#^Parameter \\#2 \\$encoderFactory of class App\\\\Security\\\\PasswordResetService constructor expects Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\EncoderFactoryInterface, object\\|null given\\.$#"
+			count: 1
+			path: tests/Unit/Security/PasswordResetServiceTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Security\\\\PasswordResetServiceTest\\:\\:\\$em \\(Doctrine\\\\ORM\\\\EntityManagerInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Security/PasswordResetServiceTest.php
+
+		-
+			message: "#^Property Tests\\\\Unit\\\\Security\\\\PasswordResetServiceTest\\:\\:\\$encoderFactory \\(Symfony\\\\Component\\\\Security\\\\Core\\\\Encoder\\\\EncoderFactoryInterface\\) does not accept object\\|null\\.$#"
+			count: 1
+			path: tests/Unit/Security/PasswordResetServiceTest.php
+
+		-
+			message: "#^You should use assertNull\\(\\) instead of assertSame\\(null, \\$actual\\)\\.$#"
+			count: 2
+			path: tests/Unit/Template/Annotation/MenuItemTest.php
+
+		-
+			message: "#^Call to an undefined method Symfony\\\\Component\\\\Dotenv\\\\Dotenv\\:\\:bootEnv\\(\\)\\.$#"
+			count: 1
+			path: tests/bootstrap.php
+
+		-
+			message: "#^Call to function method_exists\\(\\) with 'Symfony\\\\\\\\Component\\\\\\\\Dotenv\\\\\\\\Dotenv' and 'bootEnv' will always evaluate to false\\.$#"
+			count: 1
+			path: tests/bootstrap.php
+

--- a/phpstan.neon.dist
+++ b/phpstan.neon.dist
@@ -1,0 +1,14 @@
+includes:
+    - phpstan-baseline.neon
+
+parameters:
+    level: max
+    paths:
+        - src
+        - tests
+    bootstrapFiles:
+        - bin/.phpunit/phpunit/vendor/autoload.php
+    parallel:
+        jobSize: 20
+        maximumNumberOfProcesses: 32
+        minimumNumberOfJobsPerProcess: 2

--- a/src/Command/HasLocalAccountCommand.php
+++ b/src/Command/HasLocalAccountCommand.php
@@ -5,11 +5,8 @@ namespace App\Command;
 use App\Entity\Security\LocalAccount;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\Console\Command\Command;
-use Symfony\Component\Console\Input\InputArgument;
 use Symfony\Component\Console\Input\InputInterface;
 use Symfony\Component\Console\Output\OutputInterface;
-use Symfony\Component\Console\Question\Question;
-use Symfony\Component\Console\Input\InputOption;
 
 class HasLocalAccountCommand extends Command
 {

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -3,8 +3,8 @@
 namespace App\Controller\Admin;
 
 use App\Template\Annotation\MenuItem;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Activity controller.

--- a/src/Controller/Admin/EventController.php
+++ b/src/Controller/Admin/EventController.php
@@ -2,13 +2,13 @@
 
 namespace App\Controller\Admin;
 
-use App\Template\Annotation\MenuItem;
 use App\Entity\Log\Event;
 use App\Log\EventService;
+use App\Template\Annotation\MenuItem;
 use Doctrine\ORM\QueryBuilder;
-use Symfony\Component\Routing\Annotation\Route;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Event controller.
@@ -54,9 +54,9 @@ class EventController extends AbstractController
 
         $cqb = clone $qb;
         $count = current($cqb
-                    ->select('count('.$qb->getRootAlias().')')
-                    ->getQuery()
-                    ->getOneOrNullResult()
+            ->select('count('.$qb->getRootAlias().')')
+            ->getQuery()
+            ->getOneOrNullResult()
                 );
 
         $rqb = clone $qb;

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -28,7 +28,7 @@ class GroupController extends AbstractController
 
     /**
      * Generate default groups.
-     * It does require the user to create at least one board
+     * It does require the user to create at least one board.
      *
      * @Route("/generate", name="generate_default", methods={"GET", "POST"})
      */

--- a/src/Controller/Admin/MailController.php
+++ b/src/Controller/Admin/MailController.php
@@ -2,10 +2,10 @@
 
 namespace App\Controller\Admin;
 
-use App\Template\Annotation\MenuItem;
 use App\Entity\Mail\Mail;
-use Symfony\Component\Routing\Annotation\Route;
+use App\Template\Annotation\MenuItem;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Mail controller.

--- a/src/Controller/Organise/OrganiseController.php
+++ b/src/Controller/Organise/OrganiseController.php
@@ -3,9 +3,9 @@
 namespace App\Controller\Organise;
 
 use App\Entity\Activity\Activity;
-use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use App\Entity\Group\Group;
+use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
+use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Activity controller.

--- a/src/Form/Activity/ActivityCountPresent.php
+++ b/src/Form/Activity/ActivityCountPresent.php
@@ -11,7 +11,6 @@ class ActivityCountPresent extends AbstractType
 {
     public function buildForm(FormBuilderInterface $builder, array $options)
     {
-        $builder;
     }
 
     public function configureOptions(OptionsResolver $resolver)

--- a/src/Form/Activity/PriceOptionType.php
+++ b/src/Form/Activity/PriceOptionType.php
@@ -2,14 +2,14 @@
 
 namespace App\Form\Activity;
 
-use Doctrine\ORM\EntityRepository;
 use App\Entity\Activity\PriceOption;
+use Doctrine\ORM\EntityRepository;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\MoneyType;
+use Symfony\Component\Form\Extension\Core\Type\TextType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\TextType;
-use Symfony\Component\Form\Extension\Core\Type\MoneyType;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 
 class PriceOptionType extends AbstractType
 {
@@ -17,7 +17,7 @@ class PriceOptionType extends AbstractType
     {
         $builder
             ->add('name', TextType::class, [
-                'empty_data' => 'Standaard'
+                'empty_data' => 'Standaard',
             ])
             ->add('price', MoneyType::class, [
                 'divisor' => 100,
@@ -26,7 +26,7 @@ class PriceOptionType extends AbstractType
                 'label' => 'Activiteit voor',
                 'class' => 'App\Entity\Group\Group',
                 'required' => false,
-                'placeholder' => "Iedereen",
+                'placeholder' => 'Iedereen',
                 'query_builder' => function (EntityRepository $er) {
                     return $er->createQueryBuilder('t')
                         ->andWhere('t.register = TRUE');

--- a/src/Form/Group/GroupType.php
+++ b/src/Form/Group/GroupType.php
@@ -4,10 +4,10 @@ namespace App\Form\Group;
 
 use App\Entity\Group\Group;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\TextareaType;
-use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
 
 class GroupType extends AbstractType
 {

--- a/src/Form/Group/RelationAddType.php
+++ b/src/Form/Group/RelationAddType.php
@@ -3,10 +3,10 @@
 namespace App\Form\Group;
 
 use App\Entity\Group\Relation;
+use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Bridge\Doctrine\Form\Type\EntityType;
 
 class RelationAddType extends AbstractType
 {

--- a/src/Form/Security/LocalAccountType.php
+++ b/src/Form/Security/LocalAccountType.php
@@ -4,9 +4,9 @@ namespace App\Form\Security;
 
 use App\Entity\Security\LocalAccount;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
 class LocalAccountType extends AbstractType
 {

--- a/src/Form/Security/NewPasswordType.php
+++ b/src/Form/Security/NewPasswordType.php
@@ -3,10 +3,10 @@
 namespace App\Form\Security;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\PasswordType;
+use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\RepeatedType;
-use Symfony\Component\Form\Extension\Core\Type\PasswordType;
 
 class NewPasswordType extends AbstractType
 {

--- a/src/Form/Security/PasswordRequestType.php
+++ b/src/Form/Security/PasswordRequestType.php
@@ -3,9 +3,9 @@
 namespace App\Form\Security;
 
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
-use Symfony\Component\Form\Extension\Core\Type\EmailType;
 
 class PasswordRequestType extends AbstractType
 {

--- a/src/Security/LocalAuthenticator.php
+++ b/src/Security/LocalAuthenticator.php
@@ -2,14 +2,13 @@
 
 namespace App\Security;
 
-use App\EventSubscriber\ProfileUpdateSubscriber;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\RedirectResponse;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Security\Core\Authentication\Token\TokenInterface;
-use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Core\Encoder\UserPasswordEncoderInterface;
+use Symfony\Component\Security\Core\Exception\CustomUserMessageAuthenticationException;
 use Symfony\Component\Security\Core\Exception\InvalidCsrfTokenException;
 use Symfony\Component\Security\Core\Security;
 use Symfony\Component\Security\Core\User\UserInterface;

--- a/src/Template/AnnotationMenuExtension.php
+++ b/src/Template/AnnotationMenuExtension.php
@@ -3,8 +3,8 @@
 namespace App\Template;
 
 use App\Template\Annotation\MenuItem;
-use Doctrine\Common\Annotations\Reader;
 use Doctrine\Common\Annotations\AnnotationException;
+use Doctrine\Common\Annotations\Reader;
 use Symfony\Component\Finder\Finder;
 use Symfony\Component\Finder\SplFileInfo;
 
@@ -46,7 +46,6 @@ class AnnotationMenuExtension implements MenuExtensionInterface
      * @param $directory
      *   The directory of the menu items
      * @param $rootDir
-     * @param Reader $annotationReader
      */
     public function __construct($namespace, $directory, $rootDir, Reader $annotationReader)
     {

--- a/src/Tests/Database/Activity/PriceOptionFixture.php
+++ b/src/Tests/Database/Activity/PriceOptionFixture.php
@@ -4,10 +4,10 @@ namespace App\Tests\Database\Activity;
 
 use App\Entity\Activity\Activity;
 use App\Entity\Activity\PriceOption;
+use App\Tests\TestData;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Common\DataFixtures\DependentFixtureInterface;
 use Doctrine\Persistence\ObjectManager;
-use App\Tests\TestData;
 
 class PriceOptionFixture extends Fixture implements DependentFixtureInterface
 {

--- a/src/Tests/Database/Activity/RegistrationFixture.php
+++ b/src/Tests/Database/Activity/RegistrationFixture.php
@@ -2,8 +2,6 @@
 
 namespace App\Tests\Database\Activity;
 
-use App\Entity\Activity\Activity;
-use App\Entity\Activity\PriceOption;
 use App\Entity\Activity\Registration;
 use App\Entity\Order;
 use App\Repository\RegistrationRepository;

--- a/src/Tests/Database/Group/GroupFixture.php
+++ b/src/Tests/Database/Group/GroupFixture.php
@@ -3,9 +3,9 @@
 namespace App\Tests\Database\Group;
 
 use App\Entity\Group\Group;
+use App\Tests\TestData;
 use Doctrine\Bundle\FixturesBundle\Fixture;
 use Doctrine\Persistence\ObjectManager;
-use App\Tests\TestData;
 
 class GroupFixture extends Fixture
 {

--- a/src/Tests/Database/Mail/MailFixture.php
+++ b/src/Tests/Database/Mail/MailFixture.php
@@ -14,8 +14,8 @@ class MailFixture extends Fixture
         $mail = new Mail();
         $mail->setTitle('Kiwi - mail title');
         $content = json_encode([
-            'html' => "<h1>Content</h1>",
-            'plain' => "Content",
+            'html' => '<h1>Content</h1>',
+            'plain' => 'Content',
         ]);
         $mail->setContent($content);
         $mail->setSender('SenderPerson');

--- a/symfony.lock
+++ b/symfony.lock
@@ -227,6 +227,9 @@
     "phpstan/phpstan-phpunit": {
         "version": "1.0.0"
     },
+    "phpstan/phpstan-strict-rules": {
+        "version": "1.1.0"
+    },
     "phpstan/phpstan-symfony": {
         "version": "1.1.7"
     },

--- a/symfony.lock
+++ b/symfony.lock
@@ -215,6 +215,21 @@
     "phpseclib/phpseclib": {
         "version": "3.0.8"
     },
+    "phpstan/extension-installer": {
+        "version": "1.1.0"
+    },
+    "phpstan/phpstan": {
+        "version": "1.4.9"
+    },
+    "phpstan/phpstan-doctrine": {
+        "version": "1.2.11"
+    },
+    "phpstan/phpstan-phpunit": {
+        "version": "1.0.0"
+    },
+    "phpstan/phpstan-symfony": {
+        "version": "1.1.7"
+    },
     "psr/cache": {
         "version": "1.0.1"
     },

--- a/tests/Integration/Form/Activity/PriceOptionTypeTest.php
+++ b/tests/Integration/Form/Activity/PriceOptionTypeTest.php
@@ -2,8 +2,12 @@
 
 namespace Tests\Integration\Form\Activity;
 
+use App\Entity\Activity\PriceOption;
 use App\Form\Activity\PriceOptionType;
+use PHPUnit\Framework\MockObject\MockObject;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+use Symfony\Component\Form\FormFactoryInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 
 /**
  * Class PriceOptionTypeTest.
@@ -25,7 +29,6 @@ class PriceOptionTypeTest extends KernelTestCase
         parent::setUp();
         self::bootKernel();
 
-        /* @todo Correctly instantiate tested object to use it. */
         $this->priceOptionType = new PriceOptionType();
     }
 
@@ -39,15 +42,31 @@ class PriceOptionTypeTest extends KernelTestCase
         unset($this->priceOptionType);
     }
 
-    public function testBuildForm(): void
+    public function testBindValidData(): void
     {
-        /* @todo This test is incomplete. */
-        $this->markTestIncomplete();
+        $type = new PriceOption();
+        $formdata = [
+            'name' => 'testname',
+            'price' => 300,
+            'target' => null,
+        ];
+
+        /** @var FormFactoryInterface $formfactory */
+        $formfactory = self::$container->get('form.factory');
+        $form = $formfactory->create(PriceOptionType::class, $type);
+
+        $form->submit($formdata);
+        self::assertTrue($form->isSynchronized());
+        self::assertTrue($form->isSubmitted());
     }
 
     public function testConfigureOptions(): void
     {
-        /* @todo This test is incomplete. */
-        $this->markTestIncomplete();
+        /** @var OptionsResolver&MockObject $resolver */
+        $resolver = $this->getMockBuilder(OptionsResolver::class)
+            ->disableOriginalConstructor()
+            ->getMock();
+        $resolver->expects(self::exactly(1))->method('setDefaults');
+        $this->priceOptionType->configureOptions($resolver);
     }
 }


### PR DESCRIPTION
This PR adds the PhpStan static analyser to kiwi. The intention is to further improve the quality and maintainability of the codebase, by adding more automated checks to pull requests. However, this might further strain the development speed of the project. PhpStan was chosen given the fact that it's the most actively used static code analyser for PHP.

The PR integrates a number of additional phpstan extensions for Symfony, Doctrine and PHPUnit, and provides a configuration file for PhpStan which tests both source code and tests on the maximum analysis level. It has parallel processing enabled for performance and integrates with the phpunit bridge by Symfony, which provides phpunit outside of the vendor folder. A baseline has been added, which will allow for the gradual fixing of errors. The static analyser has been integrated into the CI testing pipeline (as here, it's guaranteed that phpunit was installed). Moreover, the linter has been added for good measure as well. Given that there were some linting errors present in the source, these have been autofixed as well.