### PR TITLE
Send e-mails to participants

### DIFF
--- a/templates/admin/activity/show.html.twig
+++ b/templates/admin/activity/show.html.twig
@@ -188,10 +188,9 @@
                                 <th>Aanmelding</th>
                                 <th>Optie</th>
                                 <th>Laatst bewerkt</th>
-                                <th>Acties</th>
-                                <th>Bewerk</th>
                                 <th>Aanwezigheid</th>
                                 <th>Opmerking</th>
+                                <th>Acties</th>
                             </tr>
                         </thead>
                         <tbody>
@@ -209,17 +208,19 @@
                                 <td>{{ registration.option.name }}</td>
                                 <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
                                 <td>
-                                    <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
-                                    <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
-                                </td>
-                                <td><a href="{{ path('admin_activity_registration_edit', { 'id': registration.id }) }}">Bewerk</a></td>
-                                <td>
                                 {% if registration.present is null %}Onbekend
                                 {% elseif registration.present == true %}Aanwezig
                                 {% else %}Afwezig
                                 {% endif %}
                                 </td>
-                                <td> {{registration.comment}} </td>
+                                <td>{{ registration.comment }}</td>
+                                <td>
+                                    <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
+                                    |
+                                    <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
+                                    |
+                                    <a href="{{ path('admin_activity_registration_edit', { 'id': registration.id }) }}">Bewerken</a>
+                                </td>
                             </tr>
                         {% else %}
                             <tr>
@@ -229,12 +230,13 @@
                             <tr>
                                 <td><a href="{{ path('admin_activity_registration_new', { 'id': activity.id }) }}">Aanmelding toevoegen</a></td>
                                 <td></td><td></td>
+                                <td><a href="{{ path('admin_activity_present', { 'id': activity.id }) }}">Aanwezigheid aangeven</td>
+                                <td></td>
                                 <td>
                                     {% if registrations|length > 0 %}
                                     <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}" target="_blank">Deelnemers mailen</a>
                                     {% endif %}
                                 </td>
-                                <td><a href="{{ path('admin_activity_present', { 'id': activity.id }) }}">Aanwezigheid aangeven</td>
                             </tr>
                         </tbody>
                     </table>

--- a/templates/admin/activity/show.html.twig
+++ b/templates/admin/activity/show.html.twig
@@ -200,6 +200,7 @@
                                 <td> <strike>{{ registration.person.canonical ?? 'Onbekend' }} </strike> </td>
                                 <td> <strike> {{ registration.option.name }}   </strike> </td> 
                                 <td>{{ registration.deletedate|date('Y-m-d H:i:s')  }} </td>
+                                <td><a href="mailto:{{ registration.person.email }}">Mailen</a></td>
                             </tr>
                         {% endfor %}
                         {% for registration in registrations|sort((a, b) => a.newdate <=> b.newdate) %}
@@ -207,7 +208,10 @@
                                 <td>{{ registration.person.canonical ?? 'Onbekend' }}</td>
                                 <td>{{ registration.option.name }}</td>
                                 <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
-                                <td><a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a></td>
+                                <td>
+                                    <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
+                                    <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                </td>
                                 <td><a href="{{ path('admin_activity_registration_edit', { 'id': registration.id }) }}">Bewerk</a></td>
                                 <td>
                                 {% if registration.present is null %}Onbekend
@@ -224,7 +228,12 @@
                         {% endfor %}
                             <tr>
                                 <td><a href="{{ path('admin_activity_registration_new', { 'id': activity.id }) }}">Aanmelding toevoegen</a></td>
-                                <td></td><td></td><td></td>
+                                <td></td><td></td>
+                                <td>
+                                    {% if registrations|length > 0 %}
+                                    <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}">Deelnemers mailen</a>
+                                    {% endif %}
+                                </td>
                                 <td><a href="{{ path('admin_activity_present', { 'id': activity.id }) }}">Aanwezigheid aangeven</td>
                             </tr>
                         </tbody>
@@ -255,7 +264,10 @@
                                 <td>{{ registration.person.canonical ?? 'Onbekend' }}</td>
                                 <td>{{ registration.option.name }}</td>
                                 <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
-                                <td><a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a></td>
+                                <td>
+                                    <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
+                                    <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                </td>
                                 <td>{% if not loop.first %}<a href="{{ path('admin_activity_registration_reserve_move_up', { 'id': registration.id }) }}">&uarr;</a>{% endif %}</td>
                                 <td>{% if not loop.last %}<a href="{{ path('admin_activity_registration_reserve_move_down', { 'id': registration.id }) }}">&darr;</a>{% endif %}</td>
                             </tr>

--- a/templates/admin/activity/show.html.twig
+++ b/templates/admin/activity/show.html.twig
@@ -200,7 +200,7 @@
                                 <td> <strike>{{ registration.person.canonical ?? 'Onbekend' }} </strike> </td>
                                 <td> <strike> {{ registration.option.name }}   </strike> </td> 
                                 <td>{{ registration.deletedate|date('Y-m-d H:i:s')  }} </td>
-                                <td><a href="mailto:{{ registration.person.email }}">Mailen</a></td>
+                                <td><a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a></td>
                             </tr>
                         {% endfor %}
                         {% for registration in registrations|sort((a, b) => a.newdate <=> b.newdate) %}
@@ -210,7 +210,7 @@
                                 <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
                                 <td>
                                     <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
-                                    <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                    <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
                                 </td>
                                 <td><a href="{{ path('admin_activity_registration_edit', { 'id': registration.id }) }}">Bewerk</a></td>
                                 <td>
@@ -231,7 +231,7 @@
                                 <td></td><td></td>
                                 <td>
                                     {% if registrations|length > 0 %}
-                                    <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}">Deelnemers mailen</a>
+                                    <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}" target="_blank">Deelnemers mailen</a>
                                     {% endif %}
                                 </td>
                                 <td><a href="{{ path('admin_activity_present', { 'id': activity.id }) }}">Aanwezigheid aangeven</td>
@@ -266,7 +266,7 @@
                                 <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
                                 <td>
                                     <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
-                                    <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                    <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
                                 </td>
                                 <td>{% if not loop.first %}<a href="{{ path('admin_activity_registration_reserve_move_up', { 'id': registration.id }) }}">&uarr;</a>{% endif %}</td>
                                 <td>{% if not loop.last %}<a href="{{ path('admin_activity_registration_reserve_move_down', { 'id': registration.id }) }}">&darr;</a>{% endif %}</td>

--- a/templates/admin/group/show.html.twig
+++ b/templates/admin/group/show.html.twig
@@ -96,7 +96,7 @@
                                 <tr>
                                     <th>Leden</th>
                                     <th>Aanvullende groepen</th>
-                                    <th></th>
+                                    <th>Acties</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -108,8 +108,11 @@
                                             <a href="{{ path('admin_group_show', { 'id': r.group.id }) }}">{{ r.group.name }}</a>{% if r.group.id != relation.root.group.id %} <a href="{{ path('admin_group_relation_delete', { 'id': r.id }) }}">&#128473;</a>{% endif %}{{ loop.last ? '' : ', ' }}
                                         {% endfor %}
                                     </td>
-                                    <td><a href="{{ path('admin_group_relation_add', { 'id': relation.id }) }}">Toevoegen</a></td>
-                                    <td><a href="{{ path('admin_group_relation_delete', { 'id': relation.root.id }) }}">Verwijderen</a></td>
+                                    <td>
+                                        <a href="{{ path('admin_group_relation_add', { 'id': relation.id }) }}">Toevoegen</a>
+                                        <a href="{{ path('admin_group_relation_delete', { 'id': relation.root.id }) }}">Verwijderen</a>
+                                        <a href="mailto:{{ relation.root.person.email }}" target="_blank">Mailen</a>
+                                    </td>
                                 </tr>
                             {% else %}
                                 <tr>
@@ -118,6 +121,8 @@
                             {% endfor %}
                             <tr>
                                 <td><a href="{{ path('admin_group_relation_new', { 'id': group.id }) }}">Lid toevoegen</a></td>
+                                <td></td>
+                                <td><a href="mailto:?bcc={{ group.relations|map(r => r.root.person.email)|join(',') }}" target="_blank">Groepsleden mailen</a></td>
                             </tr>
                             </tbody>
                         </table>

--- a/templates/admin/security/show.html.twig
+++ b/templates/admin/security/show.html.twig
@@ -19,7 +19,7 @@
             </tr>
             <tr>
                 <th>E-mail</th>
-                <td>{{ account.email }}</td>
+                <td><a href="mailto:{{ account.email }}" target="_blank">{{ account.email }}</a></td>
             </tr>
             <tr>
                 <th>{{ oidc ? 'Lokale login' : 'Geactiveerd' }}</th>

--- a/templates/organise/activity/show.html.twig
+++ b/templates/organise/activity/show.html.twig
@@ -35,14 +35,18 @@
                                     <td><strike>{{ registration.person.canonical ?? 'Onbekend' }}</strike></td>
                                     <td><strike>{{ registration.option.name }}</strike></td> 
                                     <td>{{ registration.deletedate|date('Y-m-d H:i:s')  }} </td>
+                                    <td><a href="mailto:{{ registration.person.email }}">Mailen</a></td>
                                 </tr>
                             {% endfor %}
-                        {% for registration in registrations|sort((a, b) => a.newdate <=> b.newdate) %}
+                            {% for registration in registrations|sort((a, b) => a.newdate <=> b.newdate) %}
                                 <tr>
                                     <td>{{ registration.person.canonical ?? 'Onbekend' }}</td>
                                     <td>{{ registration.option.name }}</td>
                                     <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
-                                    <td><a href="{{ path('organise_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a></td>
+                                    <td>
+                                        <a href="{{ path('organise_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
+                                        <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                    </td>
                                     <td><a href="{{ path('organise_activity_registration_edit', { 'id': registration.id }) }}">Bewerken</a></td>
                                     <td>{% if registration.present is null %}Onbekend
                                     {% elseif registration.present == true %}Aanwezig
@@ -57,7 +61,12 @@
                             {% endfor %}
                                 <tr>
                                     <td><a href="{{ path('organise_activity_registration_new', { 'id': activity.id }) }}">Aanmelding toevoegen</a></td>
-                                    <td></td><td></td><td></td>
+                                    <td></td><td></td>
+                                    <td>
+                                        {% if registrations|length > 0 %}
+                                        <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}">Deelnemers mailen</a>
+                                        {% endif %}
+                                    </td>
                                     <td><a href="{{ path('organise_activity_presence', { 'id': activity.id }) }}">Aanwezigheid aanpassen</a></td>
                                 </tr>
                             </tbody>
@@ -75,7 +84,10 @@
                                     <td>{{ registration.person.canonical ?? 'Onbekend' }}</td>
                                     <td>{{ registration.option.name }}</td>
                                     <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
-                                    <td><a href="{{ path('organise_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a></td>
+                                    <td>
+                                        <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
+                                        <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                    </td>
                                     <td>{% if not loop.first %}<a href="{{ path('organise_activity_registration_reserve_move_up', { 'id': registration.id }) }}">&uarr;</a>{% endif %}</td>
                                     <td>{% if not loop.last %}<a href="{{ path('organise_activity_registration_reserve_move_down', { 'id': registration.id }) }}">&darr;</a>{% endif %}</td>
                                 </tr>

--- a/templates/organise/activity/show.html.twig
+++ b/templates/organise/activity/show.html.twig
@@ -23,10 +23,9 @@
                                     <th>Aanmelding</th>
                                     <th>Optie</th>
                                     <th>Laatst bewerkt</th>
-                                    <th>Acties</th>
-                                    <th>Bewerk</th>
                                     <th>Aanwezigheid</th>
                                     <th>Opmerking</th>
+                                    <th>Acties</th>
                                 </tr>
                             </thead>
                             <tbody>
@@ -43,16 +42,18 @@
                                     <td>{{ registration.person.canonical ?? 'Onbekend' }}</td>
                                     <td>{{ registration.option.name }}</td>
                                     <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
-                                    <td>
-                                        <a href="{{ path('organise_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
-                                        <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
-                                    </td>
-                                    <td><a href="{{ path('organise_activity_registration_edit', { 'id': registration.id }) }}">Bewerken</a></td>
                                     <td>{% if registration.present is null %}Onbekend
                                     {% elseif registration.present == true %}Aanwezig
                                     {% else %}Afwezig
                                     {% endif %}</td>
-                                    <td> {{registration.comment}} </td>
+                                    <td>{{ registration.comment }}</td>
+                                    <td>
+                                        <a href="{{ path('organise_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
+                                        |
+                                        <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
+                                        |
+                                        <a href="{{ path('organise_activity_registration_edit', { 'id': registration.id }) }}">Bewerken</a>
+                                    </td>
                                 </tr>
                             {% else %}
                                 <tr>
@@ -62,12 +63,13 @@
                                 <tr>
                                     <td><a href="{{ path('organise_activity_registration_new', { 'id': activity.id }) }}">Aanmelding toevoegen</a></td>
                                     <td></td><td></td>
+                                    <td><a href="{{ path('organise_activity_presence', { 'id': activity.id }) }}">Aanwezigheid aanpassen</a></td>
+                                    <td></td>
                                     <td>
                                         {% if registrations|length > 0 %}
                                         <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}" target="_blank">Deelnemers mailen</a>
                                         {% endif %}
                                     </td>
-                                    <td><a href="{{ path('organise_activity_presence', { 'id': activity.id }) }}">Aanwezigheid aanpassen</a></td>
                                 </tr>
                             </tbody>
                             <thead>

--- a/templates/organise/activity/show.html.twig
+++ b/templates/organise/activity/show.html.twig
@@ -35,7 +35,7 @@
                                     <td><strike>{{ registration.person.canonical ?? 'Onbekend' }}</strike></td>
                                     <td><strike>{{ registration.option.name }}</strike></td> 
                                     <td>{{ registration.deletedate|date('Y-m-d H:i:s')  }} </td>
-                                    <td><a href="mailto:{{ registration.person.email }}">Mailen</a></td>
+                                    <td><a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a></td>
                                 </tr>
                             {% endfor %}
                             {% for registration in registrations|sort((a, b) => a.newdate <=> b.newdate) %}
@@ -45,7 +45,7 @@
                                     <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
                                     <td>
                                         <a href="{{ path('organise_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
-                                        <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                        <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
                                     </td>
                                     <td><a href="{{ path('organise_activity_registration_edit', { 'id': registration.id }) }}">Bewerken</a></td>
                                     <td>{% if registration.present is null %}Onbekend
@@ -64,7 +64,7 @@
                                     <td></td><td></td>
                                     <td>
                                         {% if registrations|length > 0 %}
-                                        <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}">Deelnemers mailen</a>
+                                        <a href="mailto:?bcc={{ registrations|map(r => r.person.email)|join(',') }}" target="_blank">Deelnemers mailen</a>
                                         {% endif %}
                                     </td>
                                     <td><a href="{{ path('organise_activity_presence', { 'id': activity.id }) }}">Aanwezigheid aanpassen</a></td>
@@ -86,7 +86,7 @@
                                     <td>{{ registration.newdate|date('Y-m-d H:i:s')  }} </td>
                                     <td>
                                         <a href="{{ path('admin_activity_registration_delete', { 'id': registration.id }) }}">Afmelden</a>
-                                        <a href="mailto:{{ registration.person.email }}">Mailen</a>
+                                        <a href="mailto:{{ registration.person.email }}" target="_blank">Mailen</a>
                                     </td>
                                     <td>{% if not loop.first %}<a href="{{ path('organise_activity_registration_reserve_move_up', { 'id': registration.id }) }}">&uarr;</a>{% endif %}</td>
                                     <td>{% if not loop.last %}<a href="{{ path('organise_activity_registration_reserve_move_down', { 'id': registration.id }) }}">&darr;</a>{% endif %}</td>

--- a/templates/organise/index.html.twig
+++ b/templates/organise/index.html.twig
@@ -31,7 +31,10 @@
                             </thead>
                             <tbody>
                                 <tr>
-                                    <td><a href="{{ path("organise_activity_new", { 'id': group.id }) }}" class="button add">Nieuwe activiteit</a></td>
+                                    <td>
+                                        <a href="{{ path("organise_activity_new", { 'id': group.id }) }}" class="button add">Nieuwe activiteit</a>
+                                        <a href="mailto:?bcc={{ group.relations|map(r => r.root.person.email)|join(',') }}" target="_blank" class="button">Groepsleden mailen</a>
+                                    </td>
                                 </tr>
                             </tbody>
                         </table>


### PR DESCRIPTION
This PR adds a number of buttons for admins & organisers, which allows them to send e-mails to participants for activities. A button is added for anyone individually who has registered, deregistered or is on the reserve list.

Additionally, a button is added to send a mail to all registered participants, which respects the registrants privacy by using the BCC field. The system works by utilizing the "mailto:" URL construct.