### PR TITLE
Contact options for activity participants

### DIFF
--- a/migrations/Version20220627192849.php
+++ b/migrations/Version20220627192849.php
@@ -1,0 +1,35 @@
+<?php
+
+declare(strict_types=1);
+
+namespace Migrations;
+
+use Doctrine\DBAL\Schema\Schema;
+use Doctrine\Migrations\AbstractMigration;
+
+/**
+ * Auto-generated Migration: Please modify to your needs!
+ */
+final class Version20220627192849 extends AbstractMigration
+{
+    public function getDescription(): string
+    {
+        return '';
+    }
+
+    public function up(Schema $schema): void
+    {
+        // this up() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kiwi_taxonomy ADD contact_fields LONGTEXT DEFAULT NULL COMMENT \'(DC2Type:array)\'');
+    }
+
+    public function down(Schema $schema): void
+    {
+        // this down() migration is auto-generated, please modify it to your needs
+        $this->abortIf('mysql' !== $this->connection->getDatabasePlatform()->getName(), 'Migration can only be executed safely on \'mysql\'.');
+
+        $this->addSql('ALTER TABLE kiwi_taxonomy DROP contact_fields');
+    }
+}

--- a/src/Entity/Group/Group.php
+++ b/src/Entity/Group/Group.php
@@ -75,6 +75,12 @@ class Group
     #[GQL\Description('Whether the group can be currently used as a target group for activities.')]
     private ?bool $register;
 
+    /** @var ?string[] */
+    #[ORM\Column(type: 'array', nullable: true)]
+    #[GQL\Field(type: '[string!]')]
+    #[GQL\Description('A list of contact methods.')]
+    private ?array $contactFields;
+
     public function __construct()
     {
         $this->relations = new ArrayCollection();
@@ -265,6 +271,24 @@ class Group
     public function setRegister(bool $register): self
     {
         $this->register = $register;
+
+        return $this;
+    }
+
+    /**
+     * @return string[]
+     */
+    public function getContactFields(): array
+    {
+        return $this->contactFields ?? [];
+    }
+
+    /**
+     * @param string[] $contactFields
+     */
+    public function setContactFields(array $contactFields): self
+    {
+        $this->contactFields = $contactFields;
 
         return $this;
     }

--- a/src/Form/Group/GroupType.php
+++ b/src/Form/Group/GroupType.php
@@ -4,7 +4,9 @@ namespace App\Form\Group;
 
 use App\Entity\Group\Group;
 use Symfony\Component\Form\AbstractType;
+use Symfony\Component\Form\CallbackTransformer;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
+use Symfony\Component\Form\Extension\Core\Type\EmailType;
 use Symfony\Component\Form\Extension\Core\Type\TextareaType;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
@@ -16,6 +18,10 @@ class GroupType extends AbstractType
         $builder
             ->add('name')
             ->add('description', TextareaType::class, [
+                'required' => false,
+            ])
+            ->add('contactFields', EmailType::class, [
+                'label' => 'Contact e-mailadres',
                 'required' => false,
             ])
             ->add('relationable', CheckboxType::class, [
@@ -36,6 +42,23 @@ class GroupType extends AbstractType
                 'help' => 'Doelgroepen kunnen geselecteerd worden als doelgroep voor activiteiten.',
                 'required' => false,
             ])
+        ;
+
+        $builder->get('contactFields')
+            ->addModelTransformer(new CallbackTransformer(
+                function ($emailAsArray) {
+                    // transform the array to a string
+                    return str_replace('mailto:', '', $emailAsArray['email'] ?? '');
+                },
+                function ($emailAsString) {
+                    // transform the string back to an array
+                    if ($emailAsString) {
+                        return ['email' => "mailto:$emailAsString"];
+                    }
+
+                    return [];
+                }
+            ))
         ;
     }
 

--- a/templates/activity/show.html.twig
+++ b/templates/activity/show.html.twig
@@ -81,6 +81,9 @@
                         </div>
                     </div>
                 {% endif %}
+                {% if activity.author.active and activity.author.contactFields.email %}
+                    <a href="{{ activity.author.contactFields.email }}" target="_blank" class="rounded px-4 py-3 bg-white inline-block">Contact</a>
+                {% endif %}
             </div>
         {% endif %}
     </div>

--- a/templates/activity/show.html.twig
+++ b/templates/activity/show.html.twig
@@ -81,8 +81,11 @@
                         </div>
                     </div>
                 {% endif %}
-                {% if activity.author.active and activity.author.contactFields.email %}
-                    <a href="{{ activity.author.contactFields.email }}" target="_blank" class="rounded px-4 py-3 bg-white inline-block">Contact</a>
+                {% if is_granted('ROLE_USER') and activity.author and activity.author.contactFields.email %}
+                    <a href="{{ activity.author.contactFields.email }}" target="_blank" class="rounded px-4 py-3 text-white bg-blue-500 inline-block">Contact</a>
+                {% endif %}
+                {% if is_granted('in_group', activity.author) %}
+                    <a href="{{ path("admin_activity_show", { 'activity': activity.id }) }}" target="_blank" class="rounded px-4 py-3 text-black bg-white inline-block">Beheren</a>
                 {% endif %}
             </div>
         {% endif %}

--- a/templates/admin/activity/show.html.twig
+++ b/templates/admin/activity/show.html.twig
@@ -5,6 +5,7 @@
 {% endif %}
 
 {% block buttons %}
+    <a href="{{ path("activity_show", { 'activity': activity.id }) }}" target="_blank">Openen</a>
     <a href="{{ path('admin_activity_clone', { 'base': activity.id }) }}">Kopiëren</a>
     {% if not activity.archived %}
             <a href="{{ path('admin_activity_edit', { 'activity': activity.id }) }}">Bewerken</a> 

--- a/templates/admin/group/show.html.twig
+++ b/templates/admin/group/show.html.twig
@@ -143,6 +143,10 @@
                                 <td>{{ group.description }}</td>
                             </tr>
                             <tr>
+                                <th>Contact E-mail</th>
+                                <td>{{ (group.contactFields.email ?? '')|replace({'mailto:': ''})  }}</td>
+                            </tr>
+                            <tr>
                                 <th>Mag groepsleden bevatten</th>
                                 <td>{{ group.relationable ? "Ja" : "Nee" }}</td>
                             </tr>


### PR DESCRIPTION
This PR adds the contact options to groups and a contact button next to an activity. This allows participants to ask questions to the organisation of an activity. In the initial version, it's implemented to support e-mail contact only. However, the contact fields are internally stored as an associative array, which allows for multiple contact options later on.