### PR TITLE
Version indications in the admin

### DIFF
--- a/config/packages/twig.yaml
+++ b/config/packages/twig.yaml
@@ -1,7 +1,8 @@
 #Editted
 parameters:
     env(ORG_NAME): 'Kiwi'
-    env(PROFILE_URL): ''    
+    env(PROFILE_URL): ''
+    env(INSTALLED_VERSION): ''
 
 twig:
     default_path: '%kernel.project_dir%/templates'
@@ -10,6 +11,7 @@ twig:
         org: '%env(ORG_NAME)%'
         oidc: '%env(OIDC_ADDRESS)%'
         profile_url: '%env(PROFILE_URL)%'
+        version: '%env(INSTALLED_VERSION)%'
 
 when@test:
     twig:

--- a/templates/admin/layout.html.twig
+++ b/templates/admin/layout.html.twig
@@ -78,7 +78,7 @@
             {% if app.environment == 'dev' %}
                 <li>Development mode</li>
             {% elseif version != '' %}
-                <li>versie {{ version }}</li>
+                <li>Version {{ version }}</li>
             {% endif %}
             <li>Maintained by Studio Weyne</li>
             <li>Licensed under Apache version 2.0</li>

--- a/templates/admin/layout.html.twig
+++ b/templates/admin/layout.html.twig
@@ -74,8 +74,12 @@
 {% block footer %}
     <footer class="bottom">
         <ul class="bottom-legal">
-            <li>Helpless Kiwi 0.0.1</li>
-            {% if app.environment == 'dev' %}<li>Development mode</li>{% endif %}
+            <li>Helpless Kiwi</li>
+            {% if app.environment == 'dev' %}
+                <li>Development mode</li>
+            {% elseif version != '' %}
+                <li>versie {{ version }}</li>
+            {% endif %}
             <li>Maintained by Studio Weyne</li>
             <li>Licensed under Apache version 2.0</li>
             <li>Built with &hearts; and Symfony</li>


### PR DESCRIPTION
This PR adds a version string in the footer of the admin pages. The updater scripts automatically set a value to the environment variable INSTALLED_VERSION. This commit leverages that value, by passing it on to Twig and than letting outputting it to all admin pages.