### PR TITLE
Update styling of the admin overview page

### DIFF
--- a/assets/style/admin.scss
+++ b/assets/style/admin.scss
@@ -13,6 +13,7 @@
 @import "components/base";
 @import "components/content";
 @import "components/message";
+@import "components/activity";
 @import "components/admin/nav";
 @import "components/admin/form";
 @import "components/admin/tabs";

--- a/assets/style/components/_activity.scss
+++ b/assets/style/components/_activity.scss
@@ -27,7 +27,7 @@
         word-break: break-word;
     }
 
-    &.organise {
+    &.admin {
         height: 130px;
     }
     

--- a/assets/style/main.scss
+++ b/assets/style/main.scss
@@ -14,7 +14,7 @@
 @import "components/content";
 @import "components/admin/form";
 @import "components/main/nav";
-@import "components/main/activity";
+@import "components/activity";
 @import "components/message";
 @import "components/card";
 @import "components/table";

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -36,7 +36,7 @@ class AdminController extends AbstractController
             $activities = $activitiesRepo->findAuthor($groups);
         }
 
-        // Only retain future activities
+        // Only retain current and future activities
         $activities = (new ArrayCollection($activities))->filter(fn (Activity $activity) => $activity->getEnd() > new \DateTime("now"));
 
         return $this->render('admin/index.html.twig', [

--- a/src/Tests/AuthWebTestCase.php
+++ b/src/Tests/AuthWebTestCase.php
@@ -64,7 +64,10 @@ class AuthWebTestCase extends WebTestCase
         unset($this->client);
     }
 
-    protected function login(bool $admin = true): void
+    /**
+     * @param string[] $roles
+     */
+    protected function login($roles = ['ROLE_ADMIN']): void
     {
         /** @var EntityManagerInterface */
         $em = self::getContainer()->get(EntityManagerInterface::class);
@@ -80,21 +83,9 @@ class AuthWebTestCase extends WebTestCase
 
         $user = new LocalAccount();
         $user->setEmail(LocalAccountFixture::USERNAME);
-        $roles = ['ROLE_USER'];
+        $user->setRoles($roles);
 
-        if ($admin) {
-            $roles[] = 'ROLE_ADMIN';
-        } else {
-            $group = new Group();
-            $group->setActive(true);
-            $group->setRelationable(true);
-
-            $rel = new Relation();
-            $rel->setGroup($group);
-            $user->addRelation($rel);
-        }
-
-        $token = new PostAuthenticationGuardToken($user, $firewallName, $roles);
+        $token = new PostAuthenticationGuardToken($user, $firewallName, $user->getRoles());
         $session->set('_security_'.$firewallContext, serialize($token));
         $session->save();
 

--- a/templates/admin/index.html.twig
+++ b/templates/admin/index.html.twig
@@ -7,6 +7,25 @@
     <h2>{{ page_title }}</h2>
 </div>
 <div class="container row">
-    <span>Ga naar <a href="{{ path('admin_activity_index') }}">activiteiten</a>.</span>
+    {% if activities|length > 0 %}
+        <div class="cardholder">
+            <div class="grid-x">
+                <div class="cell">
+                    {% for activity in activities %}
+                        <a href="{{ path("admin_activity_show", { 'id': activity.id }) }}" class="admin activity">
+                            {% if activity.image.name %}
+                                <img src="{{ vich_uploader_asset(activity, 'imageFile') }}" alt="{{ activity.name }}" class="bw">
+                            {% endif %}
+                            <div class="container">
+                                <h2>{{ activity.name }}</h2>
+                            </div>
+                        </a>
+                    {% endfor %}
+                </div>
+            </div>
+        </div>
+    {% else %}
+        <span>Voeg een <a href="{{ path('admin_activity_new') }}">nieuwe activiteit</a> toe.</span>
+    {% endif %}
 </div>
 {% endblock %}

--- a/tests/Functional/Controller/Admin/ActivityControllerTest.php
+++ b/tests/Functional/Controller/Admin/ActivityControllerTest.php
@@ -69,7 +69,7 @@ class ActivityControllerTest extends AuthWebTestCase
     public function testIndexActionNotAdmin(): void
     {
         $this->logout();
-        $this->login(false);
+        $this->login([]);
         $this->client->request('GET', $this->controllerEndpoint.'/');
         self::assertEquals(403, $this->client->getResponse()->getStatusCode());
     }

--- a/tests/Functional/Controller/Admin/AdminControllerTest.php
+++ b/tests/Functional/Controller/Admin/AdminControllerTest.php
@@ -3,14 +3,16 @@
 namespace Tests\Functional\Controller\Admin;
 
 use App\Controller\Admin\AdminController;
-use Symfony\Bundle\FrameworkBundle\Test\WebTestCase;
+use App\Tests\AuthWebTestCase;
+use App\Tests\Database\Activity\ActivityFixture;
+use App\Tests\Database\Security\LocalAccountFixture;
 
 /**
  * Class AdminControllerTest.
  *
  * @covers \App\Controller\Admin\AdminController
  */
-class AdminControllerTest extends WebTestCase
+class AdminControllerTest extends AuthWebTestCase
 {
     /**
      * @var AdminController
@@ -23,9 +25,12 @@ class AdminControllerTest extends WebTestCase
     protected function setUp(): void
     {
         parent::setUp();
+        $this->databaseTool->loadFixtures([
+            LocalAccountFixture::class,
+            ActivityFixture::class,
+        ]);
 
-        /* @todo Correctly instantiate tested object to use it. */
-        $this->adminController = new AdminController();
+        $this->login();
     }
 
     /**
@@ -40,7 +45,17 @@ class AdminControllerTest extends WebTestCase
 
     public function testIndexAction(): void
     {
-        /* @todo This test is incomplete. */
-        self::markTestIncomplete();
+        $this->client->request('GET', '/admin/');
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        self::assertSelectorTextContains('main h2', 'Overzicht');
+    }
+
+    public function testIndexActionNotAdmin(): void
+    {
+        $this->logout();
+        $this->login(['ROLE_AUTHOR']);
+        $this->client->request('GET', '/admin/');
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        self::assertSelectorTextContains('main h2', 'Overzicht');
     }
 }

--- a/tests/Functional/Controller/Admin/RegistrationControllerTest.php
+++ b/tests/Functional/Controller/Admin/RegistrationControllerTest.php
@@ -236,7 +236,7 @@ class RegistrationControllerTest extends AuthWebTestCase
 
         //act
         $this->logout();
-        $this->login(false);
+        $this->login([]);
         $this->client->request('GET', $url);
 
         //assert
@@ -259,7 +259,7 @@ class RegistrationControllerTest extends AuthWebTestCase
 
         //act
         $this->logout();
-        $this->login(false);
+        $this->login([]);
         $this->client->request('GET', $url);
 
         //assert


### PR DESCRIPTION
This PR updates the styling of the admin overview page. It now shows the upcoming/in progress activities, as these are likely to be the most relevant. It borrows from the old styling of the organise module.