### PR TITLE
Convert annotations into php8-native attributes

### DIFF
--- a/config/packages/graphql.yaml
+++ b/config/packages/graphql.yaml
@@ -4,9 +4,9 @@ overblog_graphql:
             query: Query
         mappings:
             types:
-                -   type: annotation
+                -   type: attribute
                     dir: "%kernel.project_dir%/src/Entity"
                     suffix: ~
-                -   type: annotation
+                -   type: attribute
                     dir: "%kernel.project_dir%/src/GraphQL"
                     suffix: ~

--- a/config/packages/vich_uploader.yaml
+++ b/config/packages/vich_uploader.yaml
@@ -1,6 +1,8 @@
 vich_uploader:
     db_driver: orm
 
+    metadata:
+        type: attribute
     mappings:
         activities:
             uri_prefix: /uploads/activities

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -43,8 +43,8 @@ services:
       alias: welp_ical.factory
 
 
-    App\Template\AnnotationMenuExtension:
-        class: App\Template\AnnotationMenuExtension
+    App\Template\AttributeMenuExtension:
+        class: App\Template\AttributeMenuExtension
         arguments: ["App\\Controller", "src/Controller", "%kernel.project_dir%"]
 
     App\Log\Doctrine\EntityEventListener:

--- a/config/services.yaml
+++ b/config/services.yaml
@@ -45,7 +45,7 @@ services:
 
     App\Template\AnnotationMenuExtension:
         class: App\Template\AnnotationMenuExtension
-        arguments: ["App\\Controller", "src/Controller", "%kernel.project_dir%", "@annotation_reader"]
+        arguments: ["App\\Controller", "src/Controller", "%kernel.project_dir%"]
 
     App\Log\Doctrine\EntityEventListener:
         tags:

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -498,12 +498,12 @@ parameters:
 		-
 			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
 			count: 1
-			path: src/Template/AnnotationMenuExtension.php
+			path: src/Template/AttributeMenuExtension.php
 
 		-
 			message: "#^Parameter \\#1 \\$objectOrClass of class ReflectionClass constructor expects class\\-string\\<T of object\\>\\|T of object, string given\\.$#"
 			count: 1
-			path: src/Template/AnnotationMenuExtension.php
+			path: src/Template/AttributeMenuExtension.php
 
 		-
 			message: "#^Cannot call method getId\\(\\) on object\\|null\\.$#"

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -511,26 +511,6 @@ parameters:
 			path: src/Security/PasswordResetService.php
 
 		-
-			message: "#^Property App\\\\Template\\\\Annotation\\\\MenuItem\\:\\:\\$path \\(string\\) does not accept string\\|null\\.$#"
-			count: 1
-			path: src/Template/Annotation/MenuItem.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, Symfony\\\\Component\\\\Routing\\\\Annotation\\\\Route\\|null given\\.$#"
-			count: 1
-			path: src/Template/AnnotationMenuExtension.php
-
-		-
-			message: "#^Only booleans are allowed in a negated boolean, array\\<string, array\\<App\\\\Template\\\\Annotation\\\\MenuItem\\>\\> given\\.$#"
-			count: 1
-			path: src/Template/AnnotationMenuExtension.php
-
-		-
-			message: "#^Only booleans are allowed in a ternary operator condition, Symfony\\\\Component\\\\Routing\\\\Annotation\\\\Route\\|null given\\.$#"
-			count: 1
-			path: src/Template/AnnotationMenuExtension.php
-
-		-
 			message: "#^Only booleans are allowed in a ternary operator condition, string given\\.$#"
 			count: 1
 			path: src/Template/AnnotationMenuExtension.php

--- a/phpstan-baseline.neon
+++ b/phpstan-baseline.neon
@@ -61,11 +61,6 @@ parameters:
 			path: src/Controller/Activity/ActivityController.php
 
 		-
-			message: "#^Only booleans are allowed in an if condition, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
-			count: 2
-			path: src/Controller/Activity/ActivityController.php
-
-		-
 			message: "#^Parameter \\#1 \\$activity of method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:createRegisterForm\\(\\) expects App\\\\Entity\\\\Activity\\\\Activity, App\\\\Entity\\\\Activity\\\\Activity\\|null given\\.$#"
 			count: 1
 			path: src/Controller/Activity/ActivityController.php
@@ -73,16 +68,6 @@ parameters:
 		-
 			message: "#^Parameter \\#1 \\$activity of method App\\\\Controller\\\\Activity\\\\ActivityController\\:\\:createUnregisterForm\\(\\) expects App\\\\Entity\\\\Activity\\\\Activity, App\\\\Entity\\\\Activity\\\\Activity\\|null given\\.$#"
 			count: 1
-			path: src/Controller/Activity/ActivityController.php
-
-		-
-			message: "#^Parameter \\#1 \\$person of method App\\\\Entity\\\\Activity\\\\Registration\\:\\:setPerson\\(\\) expects App\\\\Entity\\\\Security\\\\LocalAccount\\|null, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface\\|null given\\.$#"
-			count: 1
-			path: src/Controller/Activity/ActivityController.php
-
-		-
-			message: "#^Parameter \\#1 \\$person of method App\\\\Repository\\\\GroupRepository\\:\\:findAllFor\\(\\) expects App\\\\Entity\\\\Security\\\\LocalAccount, Symfony\\\\Component\\\\Security\\\\Core\\\\User\\\\UserInterface given\\.$#"
-			count: 2
 			path: src/Controller/Activity/ActivityController.php
 
 		-

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -53,7 +53,7 @@ class ActivityController extends AbstractController
     public function indexAction(#[CurrentUser] ?LocalAccount $user): Response
     {
         $groups = [];
-        if ($user) {
+        if ($user !== null) {
             $groups = $this->em->getRepository(Group::class)->findAllFor($user);
         }
 
@@ -178,7 +178,7 @@ class ActivityController extends AbstractController
         $reserve = $this->em->getRepository(Registration::class)->findReserve($activity);
         $hasReserve = $activity->hasCapacity() && (count($regs) >= $activity->getCapacity() || count($reserve) > 0);
         $groups = [];
-        if ($user) {
+        if ($user !== null) {
             $groups = $this->em->getRepository(Group::class)->findAllFor($user);
         }
         $targetoptions = $this->em->getRepository(PriceOption::class)->findUpcomingByGroup($activity, $groups);

--- a/src/Controller/Activity/ActivityController.php
+++ b/src/Controller/Activity/ActivityController.php
@@ -9,7 +9,7 @@ use App\Entity\Activity\Registration;
 use App\Entity\Group\Group;
 use App\Event\RegistrationAddedEvent;
 use App\Event\RegistrationRemovedEvent;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\HiddenType;
@@ -22,9 +22,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Activity controller.
- *
- * @Route("/", name="activity_")
  */
+#[Route("/", name: "activity_")]
 class ActivityController extends AbstractController
 {
     /**
@@ -45,11 +44,10 @@ class ActivityController extends AbstractController
 
     /**
      * Lists all activities.
-     *
-     * @MenuItem(title="Terug naar frontend", menu="admin-profile", class="mobile")
-     * @MenuItem(title="Activiteiten")
-     * @Route("/", name="index", methods={"GET"})
      */
+    #[MenuItem(title: "Terug naar frontend", menu: "admin-profile", class: "mobile")]
+    #[MenuItem(title: "Activiteiten")]
+    #[Route("/", name: "index", methods: ["GET"])]
     public function indexAction(): Response
     {
         $groups = [];
@@ -66,9 +64,8 @@ class ActivityController extends AbstractController
 
     /**
      * Displays a form to edit an existing activity entity.
-     *
-     * @Route("/activity/{id}/unregister", name="unregister", methods={"POST"})
      */
+    #[Route("/activity/{id}/unregister", name: "unregister", methods: ["POST"])]
     public function unregisterAction(
         Request $request,
         Activity $activity
@@ -93,9 +90,7 @@ class ActivityController extends AbstractController
         );
     }
 
-    /**
-     * @Route("/ical", methods={"GET"})
-     */
+    #[Route("/ical", methods: ["GET"])]
     public function callIcal(
         ICalProvider $iCalProvider
     ): Response {
@@ -106,9 +101,8 @@ class ActivityController extends AbstractController
 
     /**
      * Displays a form to register to an activity.
-     *
-     * @Route("/activity/{id}/register", name="register", methods={"POST"})
      */
+    #[Route("/activity/{id}/register", name: "register", methods: ["POST"])]
     public function registerAction(
         Request $request,
         Activity $activity
@@ -169,9 +163,8 @@ class ActivityController extends AbstractController
 
     /**
      * Finds and displays a activity entity.
-     *
-     * @Route("/activity/{id}", name="show", methods={"GET"})
      */
+    #[Route("/activity/{id}", name: "show", methods: ["GET"])]
     public function showAction(Activity $activity): Response
     {
         $regs = $this->em->getRepository(Registration::class)->findBy([

--- a/src/Controller/Admin/ActivityController.php
+++ b/src/Controller/Admin/ActivityController.php
@@ -197,7 +197,7 @@ class ActivityController extends AbstractController
     /**
      * Deletes a ApiKey entity.
      */
-    #[Route("/[id]/delete", name: "delete")]
+    #[Route("/{id}/delete", name: "delete")]
     public function deleteAction(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -293,7 +293,7 @@ class ActivityController extends AbstractController
     /**
      * Creates a form to set participent presence.
      */
-    #[Route("/[id]/present", name: "present")]
+    #[Route("/{id}/present", name: "present")]
     public function presentEditAction(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -339,7 +339,7 @@ class ActivityController extends AbstractController
     /**
      * Creates a form to reset amount participent present.
      */
-    #[Route("/[id]/resetamountpresent", name: "reset_amount_present")]
+    #[Route("/{id}/resetamountpresent", name: "reset_amount_present")]
     public function resetAmountPresent(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());

--- a/src/Controller/Admin/ActivityController.php
+++ b/src/Controller/Admin/ActivityController.php
@@ -20,6 +20,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
  * Activity controller.
@@ -64,13 +65,11 @@ class ActivityController extends AbstractController
      */
     #[MenuItem(title: "Activiteiten", menu: "admin", activeCriteria: "admin_activity_")]
     #[Route("/", name: "index", methods: ["GET"])]
-    public function indexAction(): Response
+    public function indexAction(#[CurrentUser] LocalAccount $user): Response
     {
         if ($this->isGranted('ROLE_ADMIN')) {
             $activities = $this->activitiesRepo->findBy([], ['start' => 'DESC']);
         } else {
-            /** @var LocalAccount */
-            $user = $this->getUser();
             $groups = $this->groupsRepo->findSubGroupsForPerson($user);
             $activities = $this->activitiesRepo->findAuthor($groups);
         }

--- a/src/Controller/Admin/ActivityController.php
+++ b/src/Controller/Admin/ActivityController.php
@@ -20,7 +20,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
  * Activity controller.
@@ -65,11 +64,13 @@ class ActivityController extends AbstractController
      */
     #[MenuItem(title: "Activiteiten", menu: "admin", activeCriteria: "admin_activity_")]
     #[Route("/", name: "index", methods: ["GET"])]
-    public function indexAction(#[CurrentUser] LocalAccount $user): Response
+    public function indexAction(): Response
     {
         if ($this->isGranted('ROLE_ADMIN')) {
             $activities = $this->activitiesRepo->findBy([], ['start' => 'DESC']);
         } else {
+            /** @var LocalAccount */
+            $user = $this->getUser();
             $groups = $this->groupsRepo->findSubGroupsForPerson($user);
             $activities = $this->activitiesRepo->findAuthor($groups);
         }

--- a/src/Controller/Admin/ActivityController.php
+++ b/src/Controller/Admin/ActivityController.php
@@ -13,7 +13,7 @@ use App\Log\EventService;
 use App\Repository\ActivityRepository;
 use App\Repository\GroupRepository;
 use App\Repository\RegistrationRepository;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
@@ -23,9 +23,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Activity controller.
- *
- * @Route("/admin/activity", name="admin_activity_")
  */
+#[Route("/admin/activity", name: "admin_activity_")]
 class ActivityController extends AbstractController
 {
     /**
@@ -62,10 +61,9 @@ class ActivityController extends AbstractController
 
     /**
      * Lists all activities.
-     *
-     * @MenuItem(title="Activiteiten", menu="admin", activeCriteria="admin_activity_")
-     * @Route("/", name="index", methods={"GET"})
      */
+    #[MenuItem(title: "Activiteiten", menu: "admin", activeCriteria: "admin_activity_")]
+    #[Route("/", name: "index", methods: ["GET"])]
     public function indexAction(): Response
     {
         if ($this->isGranted('ROLE_ADMIN')) {
@@ -84,9 +82,8 @@ class ActivityController extends AbstractController
 
     /**
      * Lists all activities with a group as author.
-     *
-     * @Route("/group/{id}", name="group", methods={"GET"})
      */
+    #[Route("/group/{id}", name: "group", methods: ["GET"])]
     public function groupAction(Group $group): Response
     {
         $activities = $this->activitiesRepo->findAuthor($this->groupsRepo->findSubGroupsFor($group));
@@ -98,9 +95,8 @@ class ActivityController extends AbstractController
 
     /**
      * Creates a new activity entity.
-     *
-     * @Route("/new", name="new", methods={"GET", "POST"})
      */
+    #[Route("/new", name: "new", methods: ["GET", "POST"])]
     public function newAction(Request $request, GroupRepository $groupRepo): Response
     {
         $activity = new Activity();
@@ -124,9 +120,8 @@ class ActivityController extends AbstractController
 
     /**
      * Finds and displays a activity entity.
-     *
-     * @Route("/{id}", name="show", methods={"GET"})
      */
+    #[Route("/{id}", name: "show", methods: ["GET"])]
     public function showAction(Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -155,9 +150,8 @@ class ActivityController extends AbstractController
 
     /**
      * Displays a form to edit an existing activity entity.
-     *
-     * @Route("/{id}/edit", name="edit", methods={"GET", "POST"})
      */
+    #[Route("/{id}/edit", name: "edit", methods: ["GET", "POST"])]
     public function editAction(Request $request, Activity $activity, GroupRepository $groupRepo): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -179,9 +173,8 @@ class ActivityController extends AbstractController
 
     /**
      * Displays a form to edit an existing activity entity.
-     *
-     * @Route("/{id}/image", name="image", methods={"GET", "POST"})
      */
+    #[Route("/{id}/image", name: "image", methods: ["GET", "POST"])]
     public function imageAction(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -203,9 +196,8 @@ class ActivityController extends AbstractController
 
     /**
      * Deletes a ApiKey entity.
-     *
-     * @Route("/{id}/delete", name="delete")
      */
+    #[Route("/[id]/delete", name: "delete")]
     public function deleteAction(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -228,9 +220,8 @@ class ActivityController extends AbstractController
 
     /**
      * Finds and displays a activity entity.
-     *
-     * @Route("/price/new/{id}", name="price_new", methods={"GET", "POST"})
      */
+    #[Route("/price/new/{id}", name: "price_new", methods: ["GET", "POST"])]
     public function priceNewAction(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -261,9 +252,8 @@ class ActivityController extends AbstractController
 
     /**
      * Finds and displays a activity entity.
-     *
-     * @Route("/price/{id}", name="price_edit", methods={"GET", "POST"})
      */
+    #[Route("/price/{id}", name: "price_edit", methods: ["GET", "POST"])]
     public function priceEditAction(Request $request, PriceOption $price): Response
     {
         if (null !== $price->getActivity()) {
@@ -302,9 +292,8 @@ class ActivityController extends AbstractController
 
     /**
      * Creates a form to set participent presence.
-     *
-     * @Route("/{id}/present", name="present")
      */
+    #[Route("/[id]/present", name: "present")]
     public function presentEditAction(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -325,9 +314,8 @@ class ActivityController extends AbstractController
 
     /**
      * Creates a form to set amount participent present.
-     *
-     * @Route("/{id}/setamountpresent", name="amount_present", methods={"GET", "POST"})
      */
+    #[Route("/{id}/setamountpresent", name: "amount_present", methods: ["GET", "POST"])]
     public function setAmountPresent(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());
@@ -350,9 +338,8 @@ class ActivityController extends AbstractController
 
     /**
      * Creates a form to reset amount participent present.
-     *
-     * @Route("/{id}/resetamountpresent", name="reset_amount_present")
      */
+    #[Route("/[id]/resetamountpresent", name: "reset_amount_present")]
     public function resetAmountPresent(Request $request, Activity $activity): Response
     {
         $this->denyAccessUnlessGranted('in_group', $activity->getAuthor());

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -11,7 +11,6 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
  * Activity controller.
@@ -24,14 +23,13 @@ class AdminController extends AbstractController
      */
     #[MenuItem(title: "Overzicht", menu: "admin", activeCriteria: "admin_index", order: -1)]
     #[Route("/", name: "index", methods: ["GET"])]
-    public function indexAction(
-        ActivityRepository $activitiesRepo,
-        GroupRepository $groupsRepo,
-        #[CurrentUser] LocalAccount $user
-    ): Response {
+    public function indexAction(ActivityRepository $activitiesRepo, GroupRepository $groupsRepo): Response
+    {
         if ($this->isGranted('ROLE_ADMIN')) {
             $activities = $activitiesRepo->findBy([], ['start' => 'DESC']);
         } else {
+            $user = $this->getUser();
+            assert($user instanceof LocalAccount);
             $groups = $groupsRepo->findSubGroupsForPerson($user);
             $activities = $activitiesRepo->findAuthor($groups);
         }

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -28,8 +28,7 @@ class AdminController extends AbstractController
         ActivityRepository $activitiesRepo,
         GroupRepository $groupsRepo,
         #[CurrentUser] LocalAccount $user
-    ): Response
-    {
+    ): Response {
         if ($this->isGranted('ROLE_ADMIN')) {
             $activities = $activitiesRepo->findBy([], ['start' => 'DESC']);
         } else {

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -11,6 +11,7 @@ use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
  * Activity controller.
@@ -23,13 +24,15 @@ class AdminController extends AbstractController
      */
     #[MenuItem(title: "Overzicht", menu: "admin", activeCriteria: "admin_index", order: -1)]
     #[Route("/", name: "index", methods: ["GET"])]
-    public function indexAction(ActivityRepository $activitiesRepo, GroupRepository $groupsRepo): Response
+    public function indexAction(
+        ActivityRepository $activitiesRepo,
+        GroupRepository $groupsRepo,
+        #[CurrentUser] LocalAccount $user
+    ): Response
     {
         if ($this->isGranted('ROLE_ADMIN')) {
             $activities = $activitiesRepo->findBy([], ['start' => 'DESC']);
         } else {
-            $user = $this->getUser();
-            assert($user instanceof LocalAccount);
             $groups = $groupsRepo->findSubGroupsForPerson($user);
             $activities = $activitiesRepo->findAuthor($groups);
         }

--- a/src/Controller/Admin/AdminController.php
+++ b/src/Controller/Admin/AdminController.php
@@ -6,7 +6,7 @@ use App\Entity\Activity\Activity;
 use App\Entity\Security\LocalAccount;
 use App\Repository\ActivityRepository;
 use App\Repository\GroupRepository;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\Common\Collections\ArrayCollection;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -14,17 +14,15 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Activity controller.
- *
- * @Route("/admin", name="admin_")
  */
+#[Route("/admin", name: "admin_")]
 class AdminController extends AbstractController
 {
     /**
      * Lists all activities.
-     *
-     * @MenuItem(title="Overzicht", menu="admin", activeCriteria="admin_index", order=-1)
-     * @Route("/", name="index", methods={"GET"})
      */
+    #[MenuItem(title: "Overzicht", menu: "admin", activeCriteria: "admin_index", order: -1)]
+    #[Route("/", name: "index", methods: ["GET"])]
     public function indexAction(ActivityRepository $activitiesRepo, GroupRepository $groupsRepo): Response
     {
         if ($this->isGranted('ROLE_ADMIN')) {

--- a/src/Controller/Admin/EventController.php
+++ b/src/Controller/Admin/EventController.php
@@ -4,7 +4,7 @@ namespace App\Controller\Admin;
 
 use App\Entity\Log\Event;
 use App\Log\EventService;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Doctrine\ORM\QueryBuilder;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
@@ -14,9 +14,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Event controller.
- *
- * @Route("/admin/event", name="admin_event_")
  */
+#[Route("/admin/event", name: "admin_event_")]
 class EventController extends AbstractController
 {
     /**
@@ -31,10 +30,9 @@ class EventController extends AbstractController
 
     /**
      * Lists all events.
-     *
-     * @MenuItem(title="Gebeurtenislog", menu="admin", role="ROLE_ADMIN")
-     * @Route("/", name="index", methods={"GET"})
      */
+    #[MenuItem(title: "Gebeurtenislog", menu: "admin", role: "ROLE_ADMIN")]
+    #[Route("/", name: "index", methods: ["GET"])]
     public function indexAction(Request $request, EntityManagerInterface $em): Response
     {
         $qb = $em->createQueryBuilder()

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -15,7 +15,6 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
-use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
  * Group category controller.
@@ -66,12 +65,11 @@ class GroupController extends AbstractController
      */
     #[MenuItem(title: "Groepen", menu: "admin")]
     #[Route("/{id?}", name: "show", methods: ["GET"])]
-    public function showAction(
-        Request $request,
-        ?Group $group,
-        GroupRepository $groupRepo,
-        #[CurrentUser] LocalAccount $user
-    ): Response {
+    public function showAction(Request $request, ?Group $group, GroupRepository $groupRepo): Response
+    {
+        /** @var LocalAccount */
+        $user = $this->getUser();
+
         if (null === $group) {
             $this->denyAccessUnlessGranted('any_group');
 

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -15,6 +15,7 @@ use Symfony\Component\Form\FormInterface;
 use Symfony\Component\HttpFoundation\Request;
 use Symfony\Component\HttpFoundation\Response;
 use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\Security\Http\Attribute\CurrentUser;
 
 /**
  * Group category controller.
@@ -65,11 +66,12 @@ class GroupController extends AbstractController
      */
     #[MenuItem(title: "Groepen", menu: "admin")]
     #[Route("/{id?}", name: "show", methods: ["GET"])]
-    public function showAction(Request $request, ?Group $group, GroupRepository $groupRepo): Response
-    {
-        /** @var LocalAccount */
-        $user = $this->getUser();
-
+    public function showAction(
+        Request $request,
+        ?Group $group,
+        GroupRepository $groupRepo,
+        #[CurrentUser] LocalAccount $user
+    ): Response {
         if (null === $group) {
             $this->denyAccessUnlessGranted('any_group');
 

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -137,7 +137,7 @@ class GroupController extends AbstractController
     /**
      * Deletes a ApiKey entity.
      */
-    #[Route("/[id]/delete", name: "delete")]
+    #[Route("/{id}/delete", name: "delete")]
     public function deleteAction(Request $request, Group $group): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $group);
@@ -234,7 +234,7 @@ class GroupController extends AbstractController
     /**
      * Deletes a ApiKey entity.
      */
-    #[Route("/relation/delete/[id]", name: "relation_delete")]
+    #[Route("/relation/delete/{id}", name: "relation_delete")]
     public function relationDeleteAction(Request $request, Relation $relation): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $relation->getGroup());

--- a/src/Controller/Admin/GroupController.php
+++ b/src/Controller/Admin/GroupController.php
@@ -8,7 +8,7 @@ use App\Entity\Security\LocalAccount;
 use App\Log\Doctrine\EntityUpdateEvent;
 use App\Log\EventService;
 use App\Repository\GroupRepository;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\FormInterface;
@@ -18,9 +18,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Group category controller.
- *
- * @Route("/admin/group", name="admin_group_")
  */
+#[Route("/admin/group", name: "admin_group_")]
 class GroupController extends AbstractController
 {
     public function __construct(
@@ -31,9 +30,8 @@ class GroupController extends AbstractController
 
     /**
      * Creates a new group entity.
-     *
-     * @Route("/new/{id?}", name="new", methods={"GET", "POST"})
      */
+    #[Route("/new/{id?}", name: "new", methods: ["GET", "POST"])]
     public function newAction(Request $request, ?Group $parent): Response
     {
         $this->denyAccessUnlessGranted('in_group', $parent);
@@ -64,10 +62,9 @@ class GroupController extends AbstractController
 
     /**
      * Lists all groups.
-     *
-     * @MenuItem(title="Groepen", menu="admin")
-     * @Route("/{id?}", name="show", methods={"GET"})
      */
+    #[MenuItem(title: "Groepen", menu: "admin")]
+    #[Route("/{id?}", name: "show", methods: ["GET"])]
     public function showAction(Request $request, ?Group $group, GroupRepository $groupRepo): Response
     {
         /** @var LocalAccount */
@@ -116,9 +113,8 @@ class GroupController extends AbstractController
 
     /**
      * Displays a form to edit an existing group entity.
-     *
-     * @Route("/{id}/edit", name="edit", methods={"GET", "POST"})
      */
+    #[Route("/{id}/edit", name: "edit", methods: ["GET", "POST"])]
     public function editAction(Request $request, Group $group): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $group);
@@ -140,9 +136,8 @@ class GroupController extends AbstractController
 
     /**
      * Deletes a ApiKey entity.
-     *
-     * @Route("/{id}/delete", name="delete")
      */
+    #[Route("/[id]/delete", name: "delete")]
     public function deleteAction(Request $request, Group $group): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $group);
@@ -165,9 +160,8 @@ class GroupController extends AbstractController
 
     /**
      * Displays a form to generate a new relation to a group entity.
-     *
-     * @Route("/relation/new/{id}", name="relation_new", methods={"GET", "POST"})
      */
+    #[Route("/relation/new/{id}", name: "relation_new", methods: ["GET", "POST"])]
     public function relationNewAction(Request $request, Group $group): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $group);
@@ -197,9 +191,8 @@ class GroupController extends AbstractController
 
     /**
      * Displays a form to generate a new relation to a group entity.
-     *
-     * @Route("/relation/add/{id}", name="relation_add", methods={"GET", "POST"})
      */
+    #[Route("/relation/add/{id}", name: "relation_add", methods: ["GET", "POST"])]
     public function relationAddAction(Request $request, Relation $parent): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $parent->getGroup());
@@ -240,9 +233,8 @@ class GroupController extends AbstractController
 
     /**
      * Deletes a ApiKey entity.
-     *
-     * @Route("/relation/delete/{id}", name="relation_delete")
      */
+    #[Route("/relation/delete/[id]", name: "relation_delete")]
     public function relationDeleteAction(Request $request, Relation $relation): Response
     {
         $this->denyAccessUnlessGranted('edit_group', $relation->getGroup());

--- a/src/Controller/Admin/MailController.php
+++ b/src/Controller/Admin/MailController.php
@@ -3,7 +3,7 @@
 namespace App\Controller\Admin;
 
 use App\Entity\Mail\Mail;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Response;
@@ -11,17 +11,15 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Mail controller.
- *
- * @Route("/admin/mail", name="admin_mail_")
  */
+#[Route("/admin/mail", name: "admin_mail_")]
 class MailController extends AbstractController
 {
     /**
      * Lists all mails.
-     *
-     * @MenuItem(title="Mails", menu="admin", role="ROLE_ADMIN")
-     * @Route("/", name="index", methods={"GET"})
      */
+    #[MenuItem(title: "Mails", menu: "admin", role: "ROLE_ADMIN")]
+    #[Route("/", name: "index", methods: ["GET"])]
     public function indexAction(EntityManagerInterface $em): Response
     {
         $mails = $em->getRepository(Mail::class)->findBy([], ['sentAt' => 'DESC']);
@@ -33,9 +31,8 @@ class MailController extends AbstractController
 
     /**
      * Finds and displays a mail entity.
-     *
-     * @Route("/{id}", name="show", methods={"GET"})
      */
+    #[Route("/{id}", name: "show", methods: ["GET"])]
     public function showAction(Mail $mail): Response
     {
         $content = json_decode($mail->getContent(), true);

--- a/src/Controller/Admin/RegistrationController.php
+++ b/src/Controller/Admin/RegistrationController.php
@@ -109,7 +109,7 @@ class RegistrationController extends AbstractController
     /**
      * Remove someones registration from an activity.
      */
-    #[Route("/delete/[id]", name: "delete")]
+    #[Route("/delete/{id}", name: "delete")]
     public function deleteAction(
         Request $request,
         Registration $registration

--- a/src/Controller/Admin/RegistrationController.php
+++ b/src/Controller/Admin/RegistrationController.php
@@ -17,9 +17,8 @@ use Symfony\Contracts\EventDispatcher\EventDispatcherInterface;
 
 /**
  * Activity controller.
- *
- * @Route("/admin/activity/register", name="admin_activity_registration_")
  */
+#[Route("/admin/activity/register", name: "admin_activity_registration_")]
 class RegistrationController extends AbstractController
 {
     /**
@@ -40,9 +39,8 @@ class RegistrationController extends AbstractController
 
     /**
      * Add someones registration from an activity.
-     *
-     * @Route("/new/{id}", name="new", methods={"GET", "POST"})
      */
+    #[Route("/new/{id}", name: "new", methods: ["GET", "POST"])]
     public function newAction(
         Request $request,
         Activity $activity
@@ -71,9 +69,8 @@ class RegistrationController extends AbstractController
 
     /**
      * Edit someones registration from an activity from admin.
-     *
-     * @Route("/edit/{id}", name="edit", methods={"GET", "POST"})
      */
+    #[Route("/edit/{id}", name: "edit", methods: ["GET", "POST"])]
     public function editAction(
         Request $request,
         Registration $registration
@@ -111,9 +108,8 @@ class RegistrationController extends AbstractController
 
     /**
      * Remove someones registration from an activity.
-     *
-     * @Route("/delete/{id}", name="delete")
      */
+    #[Route("/delete/[id]", name: "delete")]
     public function deleteAction(
         Request $request,
         Registration $registration
@@ -146,9 +142,8 @@ class RegistrationController extends AbstractController
 
     /**
      * Add someone in any acitity reserve list.
-     *
-     * @Route("/reserve/new/{id}", name="reserve_new", methods={"GET", "POST"})
      */
+    #[Route("/reserve/new/{id}", name: "reserve_new", methods: ["GET", "POST"])]
     public function reserveNewAction(
         Request $request,
         Activity $activity
@@ -183,9 +178,8 @@ class RegistrationController extends AbstractController
 
     /**
      * Promote someone in any acitity reserve list.
-     *
-     * @Route("/reserve/move/{id}/up", name="reserve_move_up", methods={"GET", "POST"})
      */
+    #[Route("/reserve/move/{id}/up", name: "reserve_move_up", methods: ["GET", "POST"])]
     public function reserveMoveUpAction(
         Registration $registration
     ): Response {
@@ -223,9 +217,8 @@ class RegistrationController extends AbstractController
 
     /**
      * Demote someone in any acitity reserve list.
-     *
-     * @Route("/reserve/move/{id}/down", name="reserve_move_down", methods={"GET", "POST"})
      */
+    #[Route("/reserve/move/{id}/down", name: "reserve_move_down", methods: ["GET", "POST"])]
     public function reserveMoveDownAction(
         Registration $registration
     ): Response {

--- a/src/Controller/Admin/SecurityController.php
+++ b/src/Controller/Admin/SecurityController.php
@@ -118,7 +118,7 @@ class SecurityController extends AbstractController
     /**
      * Deletes a ApiKey entity.
      */
-    #[Route("/[id]/delete", name: "delete")]
+    #[Route("/{id}/delete", name: "delete")]
     public function deleteAction(Request $request, LocalAccount $account): Response
     {
         $form = $this->createDeleteForm($account);

--- a/src/Controller/Admin/SecurityController.php
+++ b/src/Controller/Admin/SecurityController.php
@@ -8,7 +8,7 @@ use App\Log\Doctrine\EntityUpdateEvent;
 use App\Log\EventService;
 use App\Mail\MailService;
 use App\Security\PasswordResetService;
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\Form\Extension\Core\Type\CheckboxType;
@@ -19,9 +19,8 @@ use Symfony\Component\Routing\Annotation\Route;
 
 /**
  * Security controller.
- *
- * @Route("/admin/security", name="admin_security_")
  */
+#[Route("/admin/security", name: "admin_security_")]
 class SecurityController extends AbstractController
 {
     public function __construct(
@@ -32,10 +31,9 @@ class SecurityController extends AbstractController
 
     /**
      * Lists all local account entities.
-     *
-     * @MenuItem(title="Accounts", menu="admin", activeCriteria="admin_security_", role="ROLE_ADMIN")
-     * @Route("/", name="index", methods={"GET", "POST"})
      */
+    #[MenuItem(title: "Accounts", menu: "admin", activeCriteria: "admin_security_", role: "ROLE_ADMIN")]
+    #[Route("/", name: "index", methods: ["GET", "POST"])]
     public function indexAction(Request $request): Response
     {
         $accounts = $this->em->getRepository(LocalAccount::class)->findAll();
@@ -47,9 +45,8 @@ class SecurityController extends AbstractController
 
     /**
      * Creates a new activity entity.
-     *
-     * @Route("/new", name="new", methods={"GET", "POST"})
      */
+    #[Route("/new", name: "new", methods: ["GET", "POST"])]
     public function newAction(Request $request, PasswordResetService $passwordReset, MailService $mailer): Response
     {
         $account = new LocalAccount();
@@ -83,9 +80,8 @@ class SecurityController extends AbstractController
 
     /**
      * Finds and displays an auth entity.
-     *
-     * @Route("/{id}", name="show", methods={"GET"})
      */
+    #[Route("/{id}", name: "show", methods: ["GET"])]
     public function showAction(LocalAccount $account): Response
     {
         $createdAt = $this->events->findOneBy($account, EntityNewEvent::class);
@@ -100,9 +96,8 @@ class SecurityController extends AbstractController
 
     /**
      * Displays a form to edit an existing activity entity.
-     *
-     * @Route("/{id}/edit", name="edit", methods={"GET", "POST"})
      */
+    #[Route("/{id}/edit", name: "edit", methods: ["GET", "POST"])]
     public function editAction(Request $request, LocalAccount $account): Response
     {
         $form = $this->createForm('App\Form\Security\LocalAccountType', $account);
@@ -122,9 +117,8 @@ class SecurityController extends AbstractController
 
     /**
      * Deletes a ApiKey entity.
-     *
-     * @Route("/{id}/delete", name="delete")
      */
+    #[Route("/[id]/delete", name: "delete")]
     public function deleteAction(Request $request, LocalAccount $account): Response
     {
         $form = $this->createDeleteForm($account);
@@ -145,9 +139,8 @@ class SecurityController extends AbstractController
 
     /**
      * Displays a form to edit roles.
-     *
-     * @Route("/{id}/roles", name="roles", methods={"GET", "POST"})
      */
+    #[Route("/{id}/roles", name: "roles", methods: ["GET", "POST"])]
     public function rolesAction(Request $request, LocalAccount $account): Response
     {
         $form = $this->createRoleForm($account);

--- a/src/Controller/Security/LoginController.php
+++ b/src/Controller/Security/LoginController.php
@@ -2,7 +2,7 @@
 
 namespace App\Controller\Security;
 
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use Drenso\OidcBundle\OidcClientInterface;
 use Symfony\Bundle\FrameworkBundle\Controller\AbstractController;
 use Symfony\Component\HttpFoundation\Request;
@@ -12,9 +12,7 @@ use Symfony\Component\Security\Http\Authentication\AuthenticationUtils;
 
 class LoginController extends AbstractController
 {
-    /**
-     * @Route("/login", name="app_login")
-     */
+    #[Route("/login", name: "app_login")]
     public function login(Request $request, AuthenticationUtils $authenticationUtils, OidcClientInterface $oidc): Response
     {
         // you can't login again while you already are, redirect
@@ -45,18 +43,14 @@ class LoginController extends AbstractController
         );
     }
 
-    /**
-     * @Route("/login_check", name="app_login_check")
-     */
+    #[Route("/login_check", name: "app_login_check")]
     public function login_check(): Response
     {
         return $this->redirect('/');
     }
 
-    /**
-     * @MenuItem(title="Uitloggen", menu="admin-profile", class="mobile")
-     * @Route("/logout", name="app_logout", methods={"GET"})
-     */
+    #[MenuItem(title: "Uitloggen", menu: "admin-profile", class: "mobile")]
+    #[Route("/logout", name: "app_logout", methods: ["GET"])]
     public function logout(): Response
     {
         // controller can be blank: it will never be executed!

--- a/src/Controller/Security/PasswordController.php
+++ b/src/Controller/Security/PasswordController.php
@@ -16,9 +16,8 @@ use Symfony\Component\Security\Core\Exception\UsernameNotFoundException;
 
 /**
  * Password controller.
- *
- * @Route("/password", name="password_")
  */
+#[Route("/password", name: "password_")]
 class PasswordController extends AbstractController
 {
     public function __construct(
@@ -30,9 +29,8 @@ class PasswordController extends AbstractController
 
     /**
      * Reset password.
-     *
-     * @Route("/reset/{id}", name="reset", methods={"GET", "POST"})
      */
+    #[Route("/reset/{id}", name: "reset", methods: ["GET", "POST"])]
     public function resetAction(LocalAccount $auth, Request $request): Response
     {
         if (!$this->passwordReset->isPasswordRequestTokenValid($auth, $request->query->get('token'))) {
@@ -53,9 +51,8 @@ class PasswordController extends AbstractController
 
     /**
      * Register new password for account.
-     *
-     * @Route("/register/{id}", name="register", methods={"GET", "POST"})
      */
+    #[Route("/register/{id}", name: "register", methods: ["GET", "POST"])]
     public function registerAction(LocalAccount $auth, Request $request): Response
     {
         if (!$this->passwordReset->isPasswordRequestTokenValid($auth, $request->query->get('token'))) {
@@ -77,9 +74,8 @@ class PasswordController extends AbstractController
 
     /**
      * Request new password mail.
-     *
-     * @Route("/request", name="request", methods={"GET", "POST"})
      */
+    #[Route("/request", name: "request", methods: ["GET", "POST"])]
     public function requestAction(Request $request, LocalUserProvider $userProvider, MailService $mailer): Response
     {
         $form = $this->createForm('App\Form\Security\PasswordRequestType', []);

--- a/src/Entity/Activity/Activity.php
+++ b/src/Entity/Activity/Activity.php
@@ -165,7 +165,7 @@ class Activity
     private $present;
 
     /**
-     * @var \DateTime
+     * @var ?\DateTime
      */
     #[ORM\Column(type: "datetime", nullable: true, options: ["default" => "1970-01-01 00:00:00"])]
     #[GQL\Field(type: "DateTimeScalar")]

--- a/src/Entity/Activity/Activity.php
+++ b/src/Entity/Activity/Activity.php
@@ -16,180 +16,160 @@ use Symfony\Component\Validator\Constraints as Assert;
 use Vich\UploaderBundle\Entity\File as EmbeddedFile;
 use Vich\UploaderBundle\Mapping\Annotation as Vich;
 
-/**
- * @GQL\Type
- * @GQL\Description("Information on a physical activity that users can register themselves to.")
- * @ORM\Entity(repositoryClass="App\Repository\ActivityRepository")
- * @Vich\Uploadable
- */
+#[GQL\Type]
+#[GQL\Description("Information on a physical activity that users can register themselves to.")]
+#[ORM\Entity(repositoryClass: "App\Repository\ActivityRepository")]
+#[Vich\Uploadable]
 class Activity
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=100, name="title")
-     * @Assert\NotBlank
-     * @GQL\Field(type="String!")
-     * @GQL\Description("The name of the activity.")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 100, name: "title")]
+    #[Assert\NotBlank]
+    #[GQL\Field(type: "String!")]
+    #[GQL\Description("The name of the activity.")]
     private $name;
 
     /**
-     * @ORM\Column(type="text")
-     * @Assert\NotBlank
-     * @GQL\Field(type="String!")
-     * @GQL\Description("A textual description of the activity.")
-     *
      * @var string
      */
+    #[ORM\Column(type: "text")]
+    #[Assert\NotBlank]
+    #[GQL\Field(type: "String!")]
+    #[GQL\Description("A textual description of the activity.")]
     private $description;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Activity\PriceOption", mappedBy="activity")
-     * @GQL\Field(type="[PriceOption]")
-     * @GQL\Description("The available registration options for the activity.")
-     *
      * @var Collection<int, PriceOption>
      */
+    #[ORM\OneToMany(targetEntity: "App\Entity\Activity\PriceOption", mappedBy: "activity")]
+    #[GQL\Field(type: "[PriceOption]")]
+    #[GQL\Description("The available registration options for the activity.")]
     private $options;
 
     /**
-     * @GQL\Field(type="[Registration]")
-     * @GQL\Description("All registrations stored for this activity, regardless of option.")
-     * @ORM\OneToMany(targetEntity="App\Entity\Activity\Registration", mappedBy="activity")
-     *
      * @var Collection<int, Registration>
      */
+    #[GQL\Field(type: "[Registration]")]
+    #[GQL\Description("All registrations stored for this activity, regardless of option.")]
+    #[ORM\OneToMany(targetEntity: "App\Entity\Activity\Registration", mappedBy: "activity")]
     private $registrations;
 
     /**
-     * @ORM\OneToOne(targetEntity="App\Entity\Location\Location")
-     * @ORM\JoinColumn(name="location", referencedColumnName="id")
-     * @GQL\Field(type="Location!")
-     * @GQL\Description("The (physical) location of the activity.")
-     * @Assert\NotBlank
-     *
      * @var ?Location
      */
+    #[ORM\OneToOne(targetEntity: "App\Entity\Location\Location")]
+    #[ORM\JoinColumn(name: "location", referencedColumnName: "id")]
+    #[GQL\Field(type: "Location!")]
+    #[GQL\Description("The (physical) location of the activity.")]
+    #[Assert\NotBlank]
     private $location;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Group\Group")
-     * @ORM\JoinColumn(name="primairy_author", referencedColumnName="id", nullable=true)
-     * @GQL\Field(type="Group")
-     * @GQL\Description("The group that authored this activity.")
-     *
      * @var ?Group
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Group\Group")]
+    #[ORM\JoinColumn(name: "primairy_author", referencedColumnName: "id", nullable: true)]
+    #[GQL\Field(type: "Group")]
+    #[GQL\Description("The group that authored this activity.")]
     private $author;
 
     /**
-     * @GQL\Field(type="Group")
-     * @GQL\Description("The group of all users that can see and register to this activity.")
-     * @ORM\ManyToOne(targetEntity="App\Entity\Group\Group")
-     * @ORM\JoinColumn(name="target", referencedColumnName="id", nullable=true)
-     *
      * @var ?Group
      */
+    #[GQL\Field(type: "Group")]
+    #[GQL\Description("The group of all users that can see and register to this activity.")]
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Group\Group")]
+    #[ORM\JoinColumn(name: "target", referencedColumnName: "id", nullable: true)]
     private $target;
 
     /**
-     * @ORM\Column(type="string")
-     * @GQL\Field(type="String!")
-     * @GQL\Description("The color associated with this activity, stored for presentation purposes.")
-     * @Assert\NotBlank
-     *
      * @var string
      */
+    #[ORM\Column(type: "string")]
+    #[GQL\Field(type: "String!")]
+    #[GQL\Description("The color associated with this activity, stored for presentation purposes.")]
+    #[Assert\NotBlank]
     private $color;
 
     /**
-     * @ORM\Column(type="datetime")
-     * @GQL\Field(type="DateTimeScalar!")
-     * @GQL\Description("The date and time the activity starts.")
-     * @Assert\NotBlank
-     *
      * @var \DateTime
      */
+    #[ORM\Column(type: "datetime")]
+    #[GQL\Field(type: "DateTimeScalar!")]
+    #[GQL\Description("The date and time the activity starts.")]
+    #[Assert\NotBlank]
     private $start;
 
     /**
-     * @ORM\Column(type="datetime")
-     * @GQL\Field(type="DateTimeScalar!")
-     * @GQL\Description("The date and time the activity ends.")
-     * @Assert\NotBlank
-     * @Assert\Expression("value >= this.getStart()", message="Een activiteit kan niet eindigen voor de start.")
-     *
      * @var \DateTime
      */
+    #[ORM\Column(type: "datetime")]
+    #[GQL\Field(type: "DateTimeScalar!")]
+    #[GQL\Description("The date and time the activity ends.")]
+    #[Assert\NotBlank]
+    #[Assert\Expression("value >= this.getStart()", message: "Een activiteit kan niet eindigen voor de start.")]
     private $end;
 
     /**
-     * @ORM\Column(type="datetime")
-     * @GQL\Field(type="DateTimeScalar!")
-     * @GQL\Description("The final date and time users may (de)register for this activity.")
-     * @Assert\NotBlank
-     * @Assert\Expression("value <= this.getStart()", message="Aanmelddeadline kan niet na de start van de activiteit vallen.")
-     *
      * @var \DateTime
      */
+    #[ORM\Column(type: "datetime")]
+    #[GQL\Field(type: "DateTimeScalar!")]
+    #[GQL\Description("The final date and time users may (de)register for this activity.")]
+    #[Assert\NotBlank]
+    #[Assert\Expression("value <= this.getStart()", message: "Aanmelddeadline kan niet na de start van de activiteit vallen.")]
     private $deadline;
 
     /**
-     * @Vich\UploadableField(mapping="activities", fileNameProperty="image.name", size="image.size", mimeType="image.mimeType", originalName="image.originalName", dimensions="image.dimensions")
-     *
      * @var File
      */
+    #[Vich\UploadableField(mapping: "activities", fileNameProperty: "image.name", size: "image.size", mimeType: "image.mimeType", originalName: "image.originalName", dimensions: "image.dimensions")]
     private $imageFile;
 
     /**
-     * @ORM\Embedded(class="Vich\UploaderBundle\Entity\File")
-     *
      * @var EmbeddedFile
      */
+    #[ORM\Embedded(class: "Vich\UploaderBundle\Entity\File")]
     private $image;
 
     /**
-     * @ORM\Column(type="datetime")
-     *
      * @var \DateTime
      */
+    #[ORM\Column(type: "datetime")]
     private $imageUpdatedAt;
 
     /**
-     * @ORM\Column(type="integer", nullable=true)
-     * @GQL\Field(type="Int")
-     * @GQL\Description("The maximum number of users that can be registered for this activity.")
-     *
      * @var ?int
      */
+    #[ORM\Column(type: "integer", nullable: true)]
+    #[GQL\Field(type: "Int")]
+    #[GQL\Description("The maximum number of users that can be registered for this activity.")]
     private $capacity;
 
     /**
-     * @ORM\Column(type="integer", nullable=true)
-     * @GQL\Field(type="Int")
-     * @GQL\Description("A stored number of users that were present at this activity.")
-     *
      * @var ?int
      */
+    #[ORM\Column(type: "integer", nullable: true)]
+    #[GQL\Field(type: "Int")]
+    #[GQL\Description("A stored number of users that were present at this activity.")]
     private $present;
 
     /**
-     * @ORM\Column(type="datetime", nullable=true, options={"default" : "1970-01-01 00:00:00"})
-     * @GQL\Field(type="DateTimeScalar")
-     * @GQL\Description("The time after which the activity will be publicized.")
-     *
-     * @var ?\DateTime
+     * @var \DateTime
      */
+    #[ORM\Column(type: "datetime", nullable: true, options: ["default" => "1970-01-01 00:00:00"])]
+    #[GQL\Field(type: "DateTimeScalar")]
+    #[GQL\Description("The time after which the activity will be publicized.")]
     private $visibleAfter;
 
     /**

--- a/src/Entity/Activity/PriceOption.php
+++ b/src/Entity/Activity/PriceOption.php
@@ -9,82 +9,72 @@ use Doctrine\ORM\Mapping as ORM;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Entity(repositoryClass="App\Repository\OptionRepository")
- * @GQL\Type
- * @GQL\Description("A registration option for an activity.")
- */
+#[ORM\Entity(repositoryClass: "App\Repository\OptionRepository")]
+#[GQL\Type]
+#[GQL\Description("A registration option for an activity.")]
 class PriceOption
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=100, name="title")
-     * @Assert\NotBlank
-     * @GQL\Field(type="String!")
-     * @GQL\Description("The name of the registration option.")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 100, name: "title")]
+    #[Assert\NotBlank]
+    #[GQL\Field(type: "String!")]
+    #[GQL\Description("The name of the registration option.")]
     private $name;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Activity\Activity", inversedBy="options")
-     * @ORM\JoinColumn(name="activity", referencedColumnName="id")
-     * @GQL\Field(type="Activity!")
-     * @GQL\Description("The activity associated with this registration option.")
-     *
      * @var ?Activity
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Activity\Activity", inversedBy: "options")]
+    #[ORM\JoinColumn(name: "activity", referencedColumnName: "id")]
+    #[GQL\Field(type: "Activity!")]
+    #[GQL\Description("The activity associated with this registration option.")]
     private $activity;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Group\Group")
-     * @ORM\JoinColumn(name="target", referencedColumnName="id", nullable=true)
-     * @GQL\Field(type="Group")
-     * @GQL\Description("The target group of users that can register for this registration option.")
-     *
      * @var ?Group
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Group\Group")]
+    #[ORM\JoinColumn(name: "target", referencedColumnName: "id", nullable: true)]
+    #[GQL\Field(type: "Group")]
+    #[GQL\Description("The target group of users that can register for this registration option.")]
     private $target;
 
     /**
-     * @ORM\Column(type="integer")
-     * @GQL\Field(type="Int")
-     * @GQL\Description("The price of this option, stored in euro-cents.")
-     *
      * @var int
      */
+    #[ORM\Column(type: "integer")]
+    #[GQL\Field(type: "Int")]
+    #[GQL\Description("The price of this option, stored in euro-cents.")]
     private $price;
 
     /**
-     * @ORM\Column(type="json")
-     *
      * @var array<string, string>
      */
+    #[ORM\Column(type: "json")]
     private $details;
 
     /**
-     * @ORM\Column(type="string")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string")]
     private $confirmationMsg;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Activity\Registration", mappedBy="option")
-     * @GQL\Field(type="[Registration]")
-     * @GQL\Description("The list of registrations for this price option.")
-     *
      * @var Collection<int, Registration>
      */
+    #[ORM\OneToMany(targetEntity: "App\Entity\Activity\Registration", mappedBy: "option")]
+    #[GQL\Field(type: "[Registration]")]
+    #[GQL\Description("The list of registrations for this price option.")]
     private $registrations;
 
     public function __construct()

--- a/src/Entity/Activity/Registration.php
+++ b/src/Entity/Activity/Registration.php
@@ -9,95 +9,84 @@ use Doctrine\ORM\Mapping as ORM;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @GQL\Type
- * @GQL\Description("A representation of a registration from a user for an activity.")
- * @ORM\Entity(repositoryClass="App\Repository\RegistrationRepository")
- */
+#[GQL\Type]
+#[GQL\Description("A representation of a registration from a user for an activity.")]
+#[ORM\Entity(repositoryClass: "App\Repository\RegistrationRepository")]
 class Registration
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Activity\PriceOption", inversedBy="registrations")
-     * @ORM\JoinColumn(nullable=false)
-     * @GQL\Field(type="PriceOption!")
-     * @GQL\Description("The specific registration option of the activity this registration points to.")
-     * @Assert\NotBlank
-     *
      * @var PriceOption
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Activity\PriceOption", inversedBy: "registrations")]
+    #[ORM\JoinColumn(nullable: false)]
+    #[GQL\Field(type: "PriceOption!")]
+    #[GQL\Description("The specific registration option of the activity this registration points to.")]
+    #[Assert\NotBlank]
     private $option;
 
     /**
-     * @ORM\ManyToOne(targetEntity=LocalAccount::class, inversedBy="registrations")
-     * @ORM\JoinColumn(name="person_id", referencedColumnName="id")
-     * @GQL\Field(type="LocalAccount")
-     * @GQL\Description("The user that is registered for the activity. Only accessible if the activity is currently visible, or by admins.")
-     * @GQL\Access("isGranted('ROLE_ADMIN') or value.getActivity().isVisibleBy(getUser())")
-     *
      * @var ?LocalAccount
      */
+    #[ORM\ManyToOne(targetEntity: LocalAccount::class, inversedBy: "registrations")]
+    #[ORM\JoinColumn(name: "person_id", referencedColumnName: "id")]
+    #[GQL\Field(type: "LocalAccount")]
+    #[GQL\Description("The user that is registered for the activity. Only accessible if the activity is currently visible, or by admins.")]
+    #[GQL\Access("isGranted('ROLE_ADMIN') or value.getActivity().isVisibleBy(getUser())")]
     private $person;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Activity\Activity", inversedBy="registrations")
-     * @ORM\JoinColumn(name="activity", referencedColumnName="id")
-     * @GQL\Field(type="Activity!")
-     * @GQL\Description("The activity for which the user registered.")
-     *
      * @var ?Activity
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Activity\Activity", inversedBy: "registrations")]
+    #[ORM\JoinColumn(name: "activity", referencedColumnName: "id")]
+    #[GQL\Field(type: "Activity!")]
+    #[GQL\Description("The activity for which the user registered.")]
     private $activity;
 
     /**
-     * @ORM\Column(type="string", length=255, nullable=true)
-     * @GQL\Field(type="String")
-     * @GQL\Description("If placed on the reserve list, this value indicates their relative position, by alphabetical ordering.")
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", length: 255, nullable: true)]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("If placed on the reserve list, this value indicates their relative position, by alphabetical ordering.")]
     private $reserve_position;
 
     /**
-     * @ORM\Column(name="newdate", type="datetime", nullable=false)
-     * @GQL\Field(name="created", type="DateTimeScalar!", resolve="@=value.getNewDate()")
-     * @GQL\Description("The date and time the user registered for the activity.")
-     *
      * @var DateTime
      */
+    #[ORM\Column(name: "newdate", type: "datetime", nullable: false)]
+    #[GQL\Field(name: "created", type: "DateTimeScalar!", resolve: "@=value.getNewDate()")]
+    #[GQL\Description("The date and time the user registered for the activity.")]
     private $newdate;
 
     /**
-     * @ORM\Column(name="deletedate", type="datetime", nullable=true)
-     * @GQL\Field(name="deleted", type="DateTimeScalar", resolve="@=value.getDeleteDate()")
-     * @GQL\Description("The date and time the user deleted their registration for the activity.")
-     *
      * @var ?DateTime
      */
+    #[ORM\Column(name: "deletedate", type: "datetime", nullable: true)]
+    #[GQL\Field(name: "deleted", type: "DateTimeScalar", resolve: "@=value.getDeleteDate()")]
+    #[GQL\Description("The date and time the user deleted their registration for the activity.")]
     private $deletedate;
 
     /**
-     * @ORM\Column(name="present", type="boolean", nullable=true)
-     * @GQL\Field(type="Boolean")
-     * @GQL\Description("Whether the user was present during the activity.")
-     *
      * @var ?bool
      */
+    #[ORM\Column(name: "present", type: "boolean", nullable: true)]
+    #[GQL\Field(type: "Boolean")]
+    #[GQL\Description("Whether the user was present during the activity.")]
     private $present;
 
     /**
-     * @ORM\Column(type="string", length=255, nullable=true)
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", length: 255, nullable: true)]
     private $comment;
 
     /**

--- a/src/Entity/Group/Group.php
+++ b/src/Entity/Group/Group.php
@@ -9,113 +9,100 @@ use Doctrine\ORM\Mapping as ORM;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Symfony\Component\Validator\Constraints as Assert;
 
-/**
- * @ORM\Entity(repositoryClass="App\Repository\GroupRepository")
- * @ORM\Table("taxonomy")
- * @GQL\Type
- * @GQL\Description("A group of persons.")
- */
+#[ORM\Entity(repositoryClass: "App\Repository\GroupRepository")]
+#[ORM\Table("taxonomy")]
+#[GQL\Type]
+#[GQL\Description("A group of persons.")]
 class Group
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=100, name="title")
-     * @GQL\Field(type="String!")
-     * @GQL\Description("The name of the group.")
-     * @Assert\NotBlank
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 100, name: "title")]
+    #[GQL\Field(type: "String!")]
+    #[GQL\Description("The name of the group.")]
+    #[Assert\NotBlank]
     private $name;
 
     /**
-     * @ORM\Column(type="text", nullable=true)
-     * @GQL\Field(type="String")
-     * @GQL\Description("A textual description of the the group.")
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "text", nullable: true)]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("A textual description of the the group.")]
     private $description;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Group\Group", inversedBy="children")
-     * @ORM\JoinColumn(name="parent", referencedColumnName="id")
-     * @GQL\Field(type="Group")
-     * @GQL\Description("The parent group of this (sub)group. Note that the members don't need to be a subset of the parent group.")
-     *
      * @var ?Group
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Group\Group", inversedBy: "children")]
+    #[ORM\JoinColumn(name: "parent", referencedColumnName: "id")]
+    #[GQL\Field(type: "Group")]
+    #[GQL\Description("The parent group of this (sub)group. Note that the members don't need to be a subset of the parent group.")]
     private $parent;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Group\Group", mappedBy="parent")
-     * @GQL\Field(type="[Group]")
-     * @GQL\Description("The child (sub)groups of this group. Note that their members don't need to be a subset of this group.")
-     *
      * @var Collection<int, Group>
      */
+    #[ORM\OneToMany(targetEntity: "App\Entity\Group\Group", mappedBy: "parent")]
+    #[GQL\Field(type: "[Group]")]
+    #[GQL\Description("The child (sub)groups of this group. Note that their members don't need to be a subset of this group.")]
     protected $children;
 
     /**
-     * @ORM\Column(type="boolean")
-     * @GQL\Field(type="Boolean!")
-     * @GQL\Description("Whether the group can be modified.")
-     *
      * @var bool
      */
+    #[ORM\Column(type: "boolean")]
+    #[GQL\Field(type: "Boolean!")]
+    #[GQL\Description("Whether the group can be modified.")]
     private $readonly;
 
     /**
-     * @ORM\Column(type="boolean", nullable=true)
-     * @GQL\Field(type="Boolean")
-     * @GQL\Description("Whether the group can contain member users.")
-     *
      * @var ?bool
      */
+    #[ORM\Column(type: "boolean", nullable: true)]
+    #[GQL\Field(type: "Boolean")]
+    #[GQL\Description("Whether the group can contain member users.")]
     private $relationable;
 
     /**
-     * @ORM\Column(type="boolean", nullable=true)
-     * @GQL\Field(type="Boolean")
-     * @GQL\Description("Whether the group can contain children (sub)groups.")
-     *
      * @var ?bool
      */
+    #[ORM\Column(type: "boolean", nullable: true)]
+    #[GQL\Field(type: "Boolean")]
+    #[GQL\Description("Whether the group can contain children (sub)groups.")]
     private $subgroupable;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Group\Relation", mappedBy="group", orphanRemoval=true)
-     * @GQL\Field(type="[Relation]")
-     * @GQL\Description("The member users of this group.")
-     *
      * @var Collection<int, Relation>
      */
+    #[ORM\OneToMany(targetEntity: "App\Entity\Group\Relation", mappedBy: "group", orphanRemoval: true)]
+    #[GQL\Field(type: "[Relation]")]
+    #[GQL\Description("The member users of this group.")]
     private $relations;
 
     /**
-     * @ORM\Column(type="boolean")
-     * @GQL\Field(type="Boolean!")
-     * @GQL\Description("Whether the group is currently active, eg. whether it can organise activities.")
-     *
      * @var bool
      */
+    #[ORM\Column(type: "boolean")]
+    #[GQL\Field(type: "Boolean!")]
+    #[GQL\Description("Whether the group is currently active, eg. whether it can organise activities.")]
     private $active;
 
     /**
-     * @ORM\Column(type="boolean", nullable=true)
-     * @GQL\Field(type="Boolean")
-     * @GQL\Description("Whether the group can be currently used as a target group for activities.")
-     *
      * @var ?bool
      */
+    #[ORM\Column(type: "boolean", nullable: true)]
+    #[GQL\Field(type: "Boolean")]
+    #[GQL\Description("Whether the group can be currently used as a target group for activities.")]
     private $register;
 
     public function __construct()

--- a/src/Entity/Group/Relation.php
+++ b/src/Entity/Group/Relation.php
@@ -8,68 +8,60 @@ use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 use Overblog\GraphQLBundle\Annotation as GQL;
 
-/**
- * @ORM\Entity
- * @GQL\Type
- * @GQL\Description("A representation of membership status for a user in a group.")
- */
+#[ORM\Entity]
+#[GQL\Type]
+#[GQL\Description("A representation of membership status for a user in a group.")]
 class Relation
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=255, nullable=true)
-     * @GQL\Field(type="String")
-     * @GQL\Description("A textual description of membership status of a user in a group.")
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", length: 255, nullable: true)]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("A textual description of membership status of a user in a group.")]
     private $description;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Group\Group", inversedBy="relations")
-     * @ORM\JoinColumn(nullable=false)
-     * @GQL\Field(type="Group!")
-     * @GQL\Description("The group the user is a member of.")
-     *
      * @var Group
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Group\Group", inversedBy: "relations")]
+    #[ORM\JoinColumn(nullable: false)]
+    #[GQL\Field(type: "Group!")]
+    #[GQL\Description("The group the user is a member of.")]
     private $group;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Security\LocalAccount", inversedBy="relations")
-     * @ORM\JoinColumn(name="person_id", referencedColumnName="id")
-     * @GQL\Field(type="LocalAccount")
-     * @GQL\Description("The user who is a member of a group.")
-     * @GQL\Access("isGranted('ROLE_ADMIN')")
-     *
      * @var ?LocalAccount
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Security\LocalAccount", inversedBy: "relations")]
+    #[ORM\JoinColumn(name: "person_id", referencedColumnName: "id")]
+    #[GQL\Field(type: "LocalAccount")]
+    #[GQL\Description("The user who is a member of a group.")]
+    #[GQL\Access("isGranted('ROLE_ADMIN')")]
     private $person;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Group\Relation", inversedBy="children")
-     * @GQL\Field(type="Relation")
-     * @GQL\Description("The parent relation object, in case of multiple overlapping relations.")
-     *
      * @var ?Relation
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Group\Relation", inversedBy: "children")]
+    #[GQL\Field(type: "Relation")]
+    #[GQL\Description("The parent relation object, in case of multiple overlapping relations.")]
     private $parent;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Group\Relation", mappedBy="parent")
-     * @GQL\Field(type="[Relation]")
-     * @GQL\Description("The children relation objects, in case of multiple overlapping relations.")
-     *
      * @var Collection<int, Relation>
      */
+    #[ORM\OneToMany(targetEntity: "App\Entity\Group\Relation", mappedBy: "parent")]
+    #[GQL\Field(type: "[Relation]")]
+    #[GQL\Description("The children relation objects, in case of multiple overlapping relations.")]
     private $children;
 
     public function __construct()

--- a/src/Entity/Location/Location.php
+++ b/src/Entity/Location/Location.php
@@ -5,29 +5,25 @@ namespace App\Entity\Location;
 use Doctrine\ORM\Mapping as ORM;
 use Overblog\GraphQLBundle\Annotation as GQL;
 
-/**
- * @ORM\Entity
- * @GQL\Type
- * @GQL\Description("A physical location where activities are organized.")
- */
+#[ORM\Entity]
+#[GQL\Type]
+#[GQL\Description("A physical location where activities are organized.")]
 class Location
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string")
-     * @GQL\Field(type="String")
-     * @GQL\Description("The address of the location.")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string")]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("The address of the location.")]
     private $address;
 
     public function getId(): ?string

--- a/src/Entity/Log/Event.php
+++ b/src/Entity/Log/Event.php
@@ -8,15 +8,10 @@ use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
 
 #[ORM\Entity]
-#[ORM\Table(
-    name: "log",
-    indexes: [
-    new ORM\Index(name: "search_idx", columns: ["object_id", "object_type"]),
-    new ORM\Index(name: "order_idx", columns: ["time"]),
-    new ORM\Index(name: "discr_idx", columns: ["discr"])
-  ]
-)]
-
+#[ORM\Table(name: "log")]
+#[ORM\Index(name: "search_idx", columns: ["object_id", "object_type"])]
+#[ORM\Index(name: "order_idx", columns: ["time"])]
+#[ORM\Index(name: "discr_idx", columns: ["discr"])]
 class Event
 {
     /**

--- a/src/Entity/Log/Event.php
+++ b/src/Entity/Log/Event.php
@@ -7,69 +7,61 @@ use App\Log\AbstractEvent;
 use DateTimeInterface;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- * @ORM\Table(
- *   name="log",
- *   indexes={
- *     @ORM\Index(name="search_idx", columns={"object_id", "object_type"}),
- *     @ORM\Index(name="order_idx",  columns={"time"}),
- *     @ORM\Index(name="discr_idx",  columns={"discr"})
- *   }
- * )
- */
+#[ORM\Entity]
+#[ORM\Table(
+    name: "log",
+    indexes: [
+    new ORM\Index(name: "search_idx", columns: ["object_id", "object_type"]),
+    new ORM\Index(name: "order_idx", columns: ["time"]),
+    new ORM\Index(name: "discr_idx", columns: ["discr"])
+  ]
+)]
+
 class Event
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=100)
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 100)]
     private $discr;
 
     /**
-     * @ORM\Column(type="datetime")
-     *
      * @var DateTimeInterface
      */
+    #[ORM\Column(type: "datetime")]
     private $time;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", nullable: true)]
     private $objectId;
 
     /**
-     * @ORM\Column(type="string", nullable=true)
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", nullable: true)]
     private $objectType;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Security\LocalAccount")
-     * @ORM\JoinColumn(name="person_id", referencedColumnName="id")
-     *
      * @var ?LocalAccount
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Security\LocalAccount")]
+    #[ORM\JoinColumn(name: "person_id", referencedColumnName: "id")]
     private $person;
 
     /**
-     * @ORM\Column(type="text")
-     *
      * @var string
      */
+    #[ORM\Column(type: "text")]
     private $meta;
 
     public function getId(): ?string

--- a/src/Entity/Mail/Mail.php
+++ b/src/Entity/Mail/Mail.php
@@ -7,61 +7,52 @@ use DateTime;
 use Doctrine\Common\Collections\Collection;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Mail
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Security\LocalAccount")
-     * @ORM\JoinColumn(name="person_id", referencedColumnName="id")
-     *
      * @var ?LocalAccount
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Security\LocalAccount")]
+    #[ORM\JoinColumn(name: "person_id", referencedColumnName: "id")]
     private $person;
 
     /**
-     * @ORM\OneToMany(targetEntity="App\Entity\Mail\Recipient", mappedBy="mail")
-     *
      * @var Collection<int,Recipient>
      */
+    #[ORM\OneToMany(targetEntity: "App\Entity\Mail\Recipient", mappedBy: "mail")]
     private $recipients;
 
     /**
-     * @ORM\Column(type="string")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string")]
     private $title;
 
     /**
-     * @ORM\Column(type="text")
-     *
      * @var string
      */
+    #[ORM\Column(type: "text")]
     private $content;
 
     /**
-     * @ORM\Column(type="string", length=255)
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 255)]
     private $sender;
 
     /**
-     * @ORM\Column(type="datetime")
-     *
      * @var DateTime
      */
+    #[ORM\Column(type: "datetime")]
     private $sentAt;
 
     public function getId(): ?string

--- a/src/Entity/Mail/Recipient.php
+++ b/src/Entity/Mail/Recipient.php
@@ -5,34 +5,29 @@ namespace App\Entity\Mail;
 use App\Entity\Security\LocalAccount;
 use Doctrine\ORM\Mapping as ORM;
 
-/**
- * @ORM\Entity
- */
+#[ORM\Entity]
 class Recipient
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Security\LocalAccount")
-     * @ORM\JoinColumn(name="person_id", referencedColumnName="id")
-     *
      * @var ?LocalAccount
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Security\LocalAccount")]
+    #[ORM\JoinColumn(name: "person_id", referencedColumnName: "id")]
     private $person;
 
     /**
-     * @ORM\ManyToOne(targetEntity="App\Entity\Mail\Mail", inversedBy="recipients")
-     * @ORM\JoinColumn(name="mail", referencedColumnName="id")
-     *
      * @var ?Mail
      */
+    #[ORM\ManyToOne(targetEntity: "App\Entity\Mail\Mail", inversedBy: "recipients")]
+    #[ORM\JoinColumn(name: "mail", referencedColumnName: "id")]
     private $mail;
 
     public function getId(): ?string

--- a/src/Entity/Security/LocalAccount.php
+++ b/src/Entity/Security/LocalAccount.php
@@ -14,111 +14,98 @@ use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
 
-/**
- * @ORM\Entity
- * @GQL\Type
- * @GQL\Description("A registered user who can log in and register for activities.")
- */
+#[ORM\Entity]
+#[GQL\Type]
+#[GQL\Description("A registered user who can log in and register for activities.")]
 class LocalAccount implements UserInterface, PasswordAuthenticatedUserInterface, EquatableInterface
 {
     /**
-     * @ORM\Id()
-     * @ORM\GeneratedValue(strategy="UUID")
-     * @ORM\Column(type="guid")
-     *
      * @var ?string
      */
+    #[ORM\Id()]
+    #[ORM\GeneratedValue(strategy: "UUID")]
+    #[ORM\Column(type: "guid")]
     private $id;
 
     /**
-     * @ORM\Column(type="string", length=180, unique=true)
-     * @GQL\Field(type="String")
-     * @GQL\Description("The e-mail address of the user.")
-     * @GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 180, unique: true)]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("The e-mail address of the user.")]
+    #[GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")]
     private $email;
 
     /**
-     * @ORM\Column(type="string", length=180)
-     * @GQL\Field(type="String")
-     * @GQL\Description("The given name of the user (the first name in western cultures).")
-     * @GQL\Access("isAuthenticated()")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 180)]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("The given name of the user (the first name in western cultures).")]
+    #[GQL\Access("isAuthenticated()")]
     private $givenName;
 
     /**
-     * @ORM\Column(type="string", length=180)
-     * @GQL\Field(type="String")
-     * @GQL\Description("The family name of the user (the last name in western cultures).")
-     * @GQL\Access("isAuthenticated()")
-     *
      * @var string
      */
+    #[ORM\Column(type: "string", length: 180)]
+    #[GQL\Field(type: "String")]
+    #[GQL\Description("The family name of the user (the last name in western cultures).")]
+    #[GQL\Access("isAuthenticated()")]
     private $familyName;
 
     /**
      * The hashed password.
      *
-     * @ORM\Column(type="string", nullable=true)
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", nullable: true)]
     private $password;
 
     /**
      * The OpenID Connect subject claim value.
      *
-     * @ORM\Column(type="string", length=255, nullable=true, unique=true)
-     *
      * @var ?string
      */
+    #[ORM\Column(type: "string", length: 255, nullable: true, unique: true)]
     private $oidc;
 
     /**
-     * @ORM\Column(type="json")
-     *
      * @var string[]
      */
+    #[ORM\Column(type: "json")]
     private $roles;
 
     /**
      * Encrypted string whose value is sent to the user email address in order to (re-)set the password.
      *
-     * @ORM\Column(name="password_request_token", type="string", nullable=true)
-     *
      * @var ?string
      */
+    #[ORM\Column(name: "password_request_token", type: "string", nullable: true)]
     protected $passwordRequestToken;
 
     /**
-     * @ORM\Column(name="password_requested_at", type="datetime", nullable=true)
-     *
      * @var ?DateTime
      */
+    #[ORM\Column(name: "password_requested_at", type: "datetime", nullable: true)]
     protected $passwordRequestedAt;
 
     /**
-     * @ORM\OneToMany(targetEntity=Registration::class, mappedBy="person")
-     * @GQL\Field(type="[Registration]")
-     * @GQL\Description("All activity registrations for the user.")
-     * @GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")
-     *
      * @var Collection<int, Registration>
      */
+    #[ORM\OneToMany(targetEntity: Registration::class, mappedBy: "person")]
+    #[GQL\Field(type: "[Registration]")]
+    #[GQL\Description("All activity registrations for the user.")]
+    #[GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")]
     private $registrations;
 
     /**
-     * @ORM\OneToMany(targetEntity=Relation::class, mappedBy="person")
-     * @GQL\Field(type="[Relation]")
-     * @GQL\Description("All group membership relations for the user.")
-     * @GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")
-     *
      * @var Collection<int, Relation>
      */
+    #[ORM\OneToMany(targetEntity: Relation::class, mappedBy: "person")]
+    #[GQL\Field(type: "[Relation]")]
+    #[GQL\Description("All group membership relations for the user.")]
+    #[GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")]
     private $relations;
 
     /**
@@ -233,11 +220,9 @@ class LocalAccount implements UserInterface, PasswordAuthenticatedUserInterface,
         return $this;
     }
 
-    /**
-     * @GQL\Field(type="Boolean!")
-     * @GQL\Description("Whether this user is an administrator.")
-     * @GQL\Access("isAuthenticated()")
-     */
+    #[GQL\Field(type: "Boolean!")]
+    #[GQL\Description("Whether this user is an administrator.")]
+    #[GQL\Access("isAuthenticated()")]
     public function isAdmin(): bool
     {
         return in_array('ROLE_ADMIN', $this->getRoles(), true);

--- a/src/GraphQL/Query.php
+++ b/src/GraphQL/Query.php
@@ -9,10 +9,8 @@ use Doctrine\ORM\EntityManagerInterface;
 use Overblog\GraphQLBundle\Annotation as GQL;
 use Symfony\Component\Security\Core\Authentication\Token\Storage\TokenStorageInterface;
 
-/**
- * @GQL\Type
- * @GQL\Description("The root of all query operations.")
- */
+#[GQL\Type]
+#[GQL\Description("The root of all query operations.")]
 class Query
 {
     /**
@@ -32,11 +30,10 @@ class Query
     }
 
     /**
-     * @GQL\Field(type="[Activity]")
-     * @GQL\Description("All currently visible activities.")
-     *
      * @return Activity[]
      */
+    #[GQL\Field(type: "[Activity]")]
+    #[GQL\Description("All currently visible activities.")]
     public function current(bool $loggedIn = false): array
     {
         $groups = [];
@@ -48,33 +45,29 @@ class Query
     }
 
     /**
-     * @GQL\Field(type="[Activity]")
-     * @GQL\Description("All activities stored in the database.")
-     * @GQL\Access("isAuthenticated()")
-     *
      * @return Activity[]
      */
+    #[GQL\Field(type: "[Activity]")]
+    #[GQL\Description("All activities stored in the database.")]
+    #[GQL\Access("isAuthenticated()")]
     public function activities(): array
     {
         return $this->em->getRepository(Activity::class)->findAll();
     }
 
     /**
-     * @GQL\Field(type="[Group]")
-     * @GQL\Description("All groups stored in the database.")
-     * @GQL\Access("isAuthenticated()")
-     *
      * @return Group[]
      */
+    #[GQL\Field(type: "[Group]")]
+    #[GQL\Description("All groups stored in the database.")]
+    #[GQL\Access("isAuthenticated()")]
     public function groups(): array
     {
         return $this->em->getRepository(Group::class)->findAll();
     }
 
-    /**
-     * @GQL\Field(type="LocalAccount")
-     * @GQL\Description("The currently authenticated user.")
-     */
+    #[GQL\Field(type: "LocalAccount")]
+    #[GQL\Description("The currently authenticated user.")]
     public function user(): ?LocalAccount
     {
         if (null === $token = $this->tokenStorage->getToken()) {
@@ -90,12 +83,11 @@ class Query
     }
 
     /**
-     * @GQL\Field(type="[LocalAccount]")
-     * @GQL\Description("All users stored in the database.")
-     * @GQL\Access("isGranted('ROLE_ADMIN')")
-     *
      * @return LocalAccount[]
      */
+    #[GQL\Field(type: "[LocalAccount]")]
+    #[GQL\Description("All users stored in the database.")]
+    #[GQL\Access("isGranted('ROLE_ADMIN')")]
     public function users()
     {
         return $this->em->getRepository(LocalAccount::class)->findAll();

--- a/src/GraphQL/Types/DatetimeScalar.php
+++ b/src/GraphQL/Types/DatetimeScalar.php
@@ -4,9 +4,7 @@ namespace App\GraphQL\Types;
 
 use Overblog\GraphQLBundle\Annotation as GQL;
 
-/**
- * @GQL\Scalar(name="DateTimeScalar")
- */
+#[GQL\Scalar(name: "DateTimeScalar")]
 class DatetimeScalar
 {
     /**

--- a/src/Template/AnnotationMenuExtension.php
+++ b/src/Template/AnnotationMenuExtension.php
@@ -58,7 +58,7 @@ class AnnotationMenuExtension implements MenuExtensionInterface
      */
     public function getMenuItems(string $menu = ''): array
     {
-        if (!$this->menuItems) {
+        if (count($this->menuItems) === 0) {
             $this->discoverMenuItems();
         }
 

--- a/src/Template/Attribute/MenuItem.php
+++ b/src/Template/Attribute/MenuItem.php
@@ -15,7 +15,8 @@ class MenuItem
         private ?string $activeCriteria = null,
         private ?int $order = null,
         private ?string $path = null
-    ) { }
+    ) {
+    }
 
     public function getTitle(): string
     {

--- a/src/Template/Attribute/MenuItem.php
+++ b/src/Template/Attribute/MenuItem.php
@@ -1,51 +1,21 @@
 <?php
 
-namespace App\Template\Annotation;
+namespace App\Template\Attribute;
 
-use Doctrine\Common\Annotations\Annotation;
+use Attribute;
 
-/**
- * @Annotation
- * @Target("METHOD")
- */
+#[Attribute(Attribute::TARGET_METHOD | Attribute::IS_REPEATABLE)]
 class MenuItem
 {
-    /**
-     * @Required
-     *
-     * @var string
-     */
-    public $title;
-
-    /**
-     * @var string
-     */
-    public $menu;
-
-    /**
-     * @var string
-     */
-    public $role;
-
-    /**
-     * @var string
-     */
-    public $class;
-
-    /**
-     * @var string
-     */
-    public $activeCriteria;
-
-    /**
-     * @var int
-     */
-    public $order;
-
-    /**
-     * @var string
-     */
-    private $path;
+    public function __construct(
+        private string $title,
+        private ?string $menu = null,
+        private ?string $role = null,
+        private ?string $class = null,
+        private ?string $activeCriteria = null,
+        private ?int $order = null,
+        private ?string $path = null
+    ) { }
 
     public function getTitle(): string
     {

--- a/src/Template/AttributeMenuExtension.php
+++ b/src/Template/AttributeMenuExtension.php
@@ -12,7 +12,7 @@ use Symfony\Component\Routing\Annotation\Route;
 /**
  * @phpstan-import-type MenuItemArray from MenuExtensionInterface
  */
-class AnnotationMenuExtension implements MenuExtensionInterface
+class AttributeMenuExtension implements MenuExtensionInterface
 {
     /**
      * @var string

--- a/tests/Unit/Template/Attribute/MenuItemTest.php
+++ b/tests/Unit/Template/Attribute/MenuItemTest.php
@@ -1,15 +1,15 @@
 <?php
 
-namespace Tests\Unit\Template\Annotation;
+namespace Tests\Unit\Template\Attribute;
 
-use App\Template\Annotation\MenuItem;
+use App\Template\Attribute\MenuItem;
 use ReflectionClass;
 use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
 
 /**
  * Class MenuItemTest.
  *
- * @covers \App\Template\Annotation\MenuItem
+ * @covers \App\Template\Attribute\MenuItem
  */
 class MenuItemTest extends KernelTestCase
 {
@@ -27,7 +27,7 @@ class MenuItemTest extends KernelTestCase
         self::bootKernel();
 
         /* @todo Correctly instantiate tested object to use it. */
-        $this->menuItem = new MenuItem();
+        $this->menuItem = new MenuItem('test');
     }
 
     /**

--- a/tests/Unit/Template/AttributeMenuExtensionTest.php
+++ b/tests/Unit/Template/AttributeMenuExtensionTest.php
@@ -1,0 +1,69 @@
+<?php
+
+namespace Tests\Unit\Template;
+
+use App\Template\Attribute\MenuItem;
+use App\Template\AttributeMenuExtension;
+use Symfony\Bundle\FrameworkBundle\Test\KernelTestCase;
+
+/**
+ * Class AttributeMenuExtensionTest.
+ *
+ * @covers \App\Template\AttributeMenuExtension
+ */
+class AttributeMenuExtensionTest extends KernelTestCase
+{
+    /**
+     * @var AttributeMenuExtension
+     */
+    protected $attributeMenuExtension;
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function setUp(): void
+    {
+        parent::setUp();
+        self::bootKernel();
+
+        $this->attributeMenuExtension = new AttributeMenuExtension('Tests\Unit\Template', __DIR__, '');
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    protected function tearDown(): void
+    {
+        parent::tearDown();
+
+        unset($this->attributeMenuExtension);
+    }
+
+    #[MenuItem('test1', path: '/')]
+    public function testGetMenuItems(): void
+    {
+        $items = $this->attributeMenuExtension->getMenuItems();
+
+        self::assertNotEmpty($items);
+        self::assertEquals('test1', reset($items)['title']);
+    }
+
+    #[MenuItem('testOther', path: '/', menu: 'other')]
+    public function testGetMenuItemsOther(): void
+    {
+        $items = $this->attributeMenuExtension->getMenuItems('other');
+
+        self::assertNotEmpty($items);
+        self::assertCount(1, $items);
+        self::assertEquals('testOther', reset($items)['title']);
+    }
+
+    #[MenuItem('testDup1', path: '/1', menu: 'duplicate')]
+    #[MenuItem('testDup2', path: '/2', menu: 'duplicate')]
+    public function testGetMenuItemsDuplicate(): void
+    {
+        $items = $this->attributeMenuExtension->getMenuItems('duplicate');
+
+        self::assertCount(2, $items);
+    }
+}


### PR DESCRIPTION
This PR converts all phpdoc-style annotations into php8 attributes. Although they're functionally identical, attributes benefit from IDE- autocomplete capabilities, as they're language elements. To enable these attributes, both the GraphQL bundle and VichUploader bundle configs were updated to utilize attributes. Moreover, the MenuItem annotation was converted into the MenuItem attribute and the AnnotationMenuExtension was updated to use the PHP reflection system, instead of the Doctrine AnnotationReader.