### PR TITLE
OpenID Connect remember me

### DIFF
--- a/config/packages/security.yaml
+++ b/config/packages/security.yaml
@@ -25,7 +25,8 @@ security:
             security: false
         main:
             lazy: true
-            oidc: ~
+            oidc:
+                enable_remember_me: true
             provider: app_user_provider
             form_login:
                 login_path: app_login


### PR DESCRIPTION
With the upgrade to PHP8 and the changes to the OpenID Connect setup, the "Remember Me" functionality was inadvertently disabled for OIDC logins. This PR intends to rectify that change.