### PR TITLE
Remove reserve list names from frontend

### DIFF
--- a/templates/activity/show.html.twig
+++ b/templates/activity/show.html.twig
@@ -99,28 +99,6 @@
                         </tbody>
                     </table>
             </div>
-            {% if activity.reserveRegistrations|length > 0 %}
-            <div class="card">
-                    <table>
-                        <thead>
-                            <tr>
-                                <th>Reservelijst</th>
-                            </tr>
-                        </thead>
-                        <tbody>
-                        {% for registration in activity.reserveRegistrations|map(a => a.person.name ?? a.person.shortname ?? 'Onbekend')|sort((a, b) => a <=> b) %}
-                            <tr>
-                                <td>{{ registration }}</td>
-                            </tr>
-                        {% else %}
-                            <tr>
-                                <td>Geen aanmeldingen reserve.</td>
-                            </tr>
-                        {% endfor %}
-                        </tbody>
-                    </table>
-            </div>
-            {% endif %}
         </div>
         {% endif %}
     </div>


### PR DESCRIPTION
This PR removes the reserve list names from the frontend. The functionality serves no practical purpose and can therefore be removed.