### PR TITLE
chore: add error handling to account import

### DIFF
--- a/src/Entity/Security/LocalAccount.php
+++ b/src/Entity/Security/LocalAccount.php
@@ -12,6 +12,7 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
+use Symfony\Component\Validator\Constraints;
 
 #[ORM\Entity]
 #[UniqueEntity(
@@ -32,6 +33,7 @@ class LocalAccount implements UserInterface, PasswordAuthenticatedUserInterface,
     #[GQL\Field(type: 'String')]
     #[GQL\Description('The e-mail address of the user.')]
     #[GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")]
+    #[Constraints\Unique(message: 'This email is already in use.', groups: ['Unique'])]
     private ?string $email = null;
 
     #[ORM\Column(type: 'string', length: 180)]
@@ -50,6 +52,7 @@ class LocalAccount implements UserInterface, PasswordAuthenticatedUserInterface,
     private ?string $password = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true, unique: true)]
+    #[Constraints\Unique(message: 'This OpenID Connect sub is already in use.', groups: ['Unique'])]
     private ?string $oidc = null;
 
     /** @var string[] */

--- a/src/Entity/Security/LocalAccount.php
+++ b/src/Entity/Security/LocalAccount.php
@@ -12,12 +12,15 @@ use Symfony\Bridge\Doctrine\Validator\Constraints\UniqueEntity;
 use Symfony\Component\Security\Core\User\EquatableInterface;
 use Symfony\Component\Security\Core\User\PasswordAuthenticatedUserInterface;
 use Symfony\Component\Security\Core\User\UserInterface;
-use Symfony\Component\Validator\Constraints;
 
 #[ORM\Entity]
 #[UniqueEntity(
     fields: 'email',
     message: 'This e-mail address is already in use.'
+)]
+#[UniqueEntity(
+    fields: 'oidc',
+    message: 'This OpenID Connect sub is already in use.'
 )]
 #[GQL\Type]
 #[GQL\Description('A registered user who can log in and register for activities.')]
@@ -33,7 +36,6 @@ class LocalAccount implements UserInterface, PasswordAuthenticatedUserInterface,
     #[GQL\Field(type: 'String')]
     #[GQL\Description('The e-mail address of the user.')]
     #[GQL\Access("isGranted('ROLE_ADMIN') or value == getUser()")]
-    #[Constraints\Unique(message: 'This email is already in use.', groups: ['Unique'])]
     private ?string $email = null;
 
     #[ORM\Column(type: 'string', length: 180)]
@@ -52,7 +54,6 @@ class LocalAccount implements UserInterface, PasswordAuthenticatedUserInterface,
     private ?string $password = null;
 
     #[ORM\Column(type: 'string', length: 255, nullable: true, unique: true)]
-    #[Constraints\Unique(message: 'This OpenID Connect sub is already in use.', groups: ['Unique'])]
     private ?string $oidc = null;
 
     /** @var string[] */

--- a/src/Form/Security/Import/ImportAccountsFlow.php
+++ b/src/Form/Security/Import/ImportAccountsFlow.php
@@ -20,6 +20,9 @@ class ImportAccountsFlow extends FormFlow
             [
                 'label' => 'upload',
                 'form_type' => UploadCsvType::class,
+                'form_options' => [
+                    'validation_groups' => ['Default', 'Unique'],
+                ],
             ],
             [
                 'label' => 'confirmation',

--- a/src/Form/Security/Import/ImportAccountsFlow.php
+++ b/src/Form/Security/Import/ImportAccountsFlow.php
@@ -21,7 +21,7 @@ class ImportAccountsFlow extends FormFlow
                 'label' => 'upload',
                 'form_type' => UploadCsvType::class,
                 'form_options' => [
-                    'validation_groups' => ['Default', 'Unique'],
+                    'validation_groups' => ['Default'],
                 ],
             ],
             [

--- a/src/Form/Security/Import/UploadCsvType.php
+++ b/src/Form/Security/Import/UploadCsvType.php
@@ -17,7 +17,7 @@ class UploadCsvType extends AbstractType
                 'constraints' => [
                     new File([
                         'maxSize' => '8M',
-                        'mimeTypes' => ['text/csv'],
+                        'mimeTypes' => ['text/plain', 'text/csv'],
                         'mimeTypesMessage' => 'Please upload a .csv file',
                     ]),
                 ],

--- a/tests/Functional/Controller/Admin/SecurityControllerTest.php
+++ b/tests/Functional/Controller/Admin/SecurityControllerTest.php
@@ -62,8 +62,9 @@ class SecurityControllerTest extends AuthWebTestCase
     public function testImportAction(): void
     {
         // Mock the CSV file
-        $csvContent = "email,given_name,family_name,admin,oidc\njohn@doe.kiwi,john,doe,User,,false";
-        $csvPath = sys_get_temp_dir().'/test.csv';
+        $csvContent = 'email,given_name,family_name,admin,oidc
+        john@doe.kiwi,john,doe,User,,false';
+        $csvPath = tempnam(sys_get_temp_dir(), 'csv');
         file_put_contents($csvPath, $csvContent);
         $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
 
@@ -90,6 +91,51 @@ class SecurityControllerTest extends AuthWebTestCase
         // second Assert
         self::assertEquals(200, $this->client->getResponse()->getStatusCode());
         self::assertSelectorTextContains('.container', 'Accounts succesvol geimporteerd');
+        unlink($csvPath);
+    }
+
+    public function testDuplicateEmailImportAction(): void
+    {
+        $csvContent = <<<CSV
+email,given_name,family_name,oidc,admin
+example2@user.kiwi,Example,User,,false
+example@user.kiwi,Example,User,,false
+example3@user.kiwi,Example,User,,false
+example4@user.kiwi,Example,User,,false
+example5@user.kiwi,Example,User,,false
+example4@user.kiwi,Example,User,1234,false
+example@user.kiwi,Example,User,1234,false 
+CSV;
+        // Mock the CSV file
+        $csvPath = tempnam(sys_get_temp_dir(), 'csv');
+        file_put_contents($csvPath, $csvContent);
+        $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
+
+        // first Act
+        $crawler = $this->client->request('GET', $this->endpoint.'/import');
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $form = $crawler->selectButton('verder')->form();
+        $form->setValues([
+            'upload_csv[file]' => $csvFile->getPathname(),
+        ]);
+        $crawler = $this->client->submit($form);
+
+        // Assert
+        self::assertEquals(200, $this->client->getResponse()->getStatusCode());
+        $formFilter = $crawler->filter('body > main > div.container.row > div > div > form');
+        self::assertEquals(
+            $formFilter->filter('ul > li:nth-child(1)')->text(),
+            'Duplicate email "example@user.kiwi" found 2 times'
+        );
+        self::assertEquals(
+            $formFilter->filter('ul > li:nth-child(2)')->text(),
+            'Duplicate email "example4@user.kiwi" found 2 times'
+        );
+        self::assertEquals(
+            $formFilter->filter('ul > li:nth-child(3)')->text(),
+            'Duplicate oidc "1234" found 2 times'
+        );
+        unlink($csvPath);
     }
 
     public function testNewAction(): void

--- a/tests/Functional/Controller/Admin/SecurityControllerTest.php
+++ b/tests/Functional/Controller/Admin/SecurityControllerTest.php
@@ -10,6 +10,8 @@ use App\Tests\Database\Security\LocalAccountFixture;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
+use function PHPUnit\Framework\assertIsString;
+
 /**
  * Class SecurityControllerTest.
  *
@@ -65,6 +67,7 @@ class SecurityControllerTest extends AuthWebTestCase
         $csvContent = 'email,given_name,family_name,admin,oidc
         john@doe.kiwi,john,doe,User,,false';
         $csvPath = tempnam(sys_get_temp_dir(), 'csv');
+        assertIsString($csvPath);
         file_put_contents($csvPath, $csvContent);
         $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
 
@@ -108,6 +111,7 @@ example@user.kiwi,Example,User,1234,false
 CSV;
         // Mock the CSV file
         $csvPath = tempnam(sys_get_temp_dir(), 'csv');
+        assertIsString($csvPath);
         file_put_contents($csvPath, $csvContent);
         $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
 

--- a/tests/Functional/Controller/Admin/SecurityControllerTest.php
+++ b/tests/Functional/Controller/Admin/SecurityControllerTest.php
@@ -25,9 +25,6 @@ class SecurityControllerTest extends AuthWebTestCase
 
     protected string $endpoint = '/admin/security';
 
-    /**
-     * {@inheritdoc}
-     */
     protected function setUp(): void
     {
         parent::setUp();
@@ -40,9 +37,6 @@ class SecurityControllerTest extends AuthWebTestCase
         $this->em = self::getContainer()->get(EntityManagerInterface::class);
     }
 
-    /**
-     * {@inheritdoc}
-     */
     protected function tearDown(): void
     {
         parent::tearDown();
@@ -68,7 +62,7 @@ class SecurityControllerTest extends AuthWebTestCase
     public function testImportAction(): void
     {
         // Mock the CSV file
-        $csvContent = "email,given_name,family_name,admin,oidc\n";
+        $csvContent = "email,given_name,family_name,admin,oidc\njohn@doe.kiwi,john,doe,User,,false";
         $csvPath = sys_get_temp_dir().'/test.csv';
         file_put_contents($csvPath, $csvContent);
         $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
@@ -89,7 +83,7 @@ class SecurityControllerTest extends AuthWebTestCase
             $crawler->filter('h3')->first()->text()
         );
 
-        // second Act
+        // // second Act
         $form = $crawler->selectButton('afronden')->form();
         $crawler = $this->client->submit($form);
 

--- a/tests/Functional/Controller/Admin/SecurityControllerTest.php
+++ b/tests/Functional/Controller/Admin/SecurityControllerTest.php
@@ -10,8 +10,6 @@ use App\Tests\Database\Security\LocalAccountFixture;
 use Doctrine\ORM\EntityManagerInterface;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
 
-use function PHPUnit\Framework\assertIsString;
-
 /**
  * Class SecurityControllerTest.
  *
@@ -67,7 +65,7 @@ class SecurityControllerTest extends AuthWebTestCase
         $csvContent = 'email,given_name,family_name,admin,oidc
         john@doe.kiwi,john,doe,User,,false';
         $csvPath = tempnam(sys_get_temp_dir(), 'csv');
-        assertIsString($csvPath);
+        self::assertIsString($csvPath);
         file_put_contents($csvPath, $csvContent);
         $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
 
@@ -87,7 +85,7 @@ class SecurityControllerTest extends AuthWebTestCase
             $crawler->filter('h3')->first()->text()
         );
 
-        // // second Act
+        // second Act
         $form = $crawler->selectButton('afronden')->form();
         $crawler = $this->client->submit($form);
 
@@ -111,7 +109,7 @@ example@user.kiwi,Example,User,1234,false
 CSV;
         // Mock the CSV file
         $csvPath = tempnam(sys_get_temp_dir(), 'csv');
-        assertIsString($csvPath);
+        self::assertIsString($csvPath);
         file_put_contents($csvPath, $csvContent);
         $csvFile = new UploadedFile($csvPath, 'test.csv', 'text/csv', null, true);
 


### PR DESCRIPTION
fixed the non existent error handing for the account import, and added a check to make sure it doesn't contain any duplicate email or oidc fields.