### PR TITLE
Update MailNotificationSubscriber.php

### DIFF
--- a/src/EventSubscriber/MailNotificationSubscriber.php
+++ b/src/EventSubscriber/MailNotificationSubscriber.php
@@ -27,7 +27,7 @@ class MailNotificationSubscriber implements EventSubscriberInterface
         Security $security,
     ) {
         $user = $security->getUser();
-        assert($user instanceof LocalAccount);
+        assert($user instanceof LocalAccount || is_null($user));
         $this->user = $user;
     }
 


### PR DESCRIPTION
When the createUser command is callled from CMD, the security user is null.

However the createAccount event expects a LocalAccount. This is fixed by including a is_null in the assert.